### PR TITLE
Fix doc section break

### DIFF
--- a/Backend/README.md
+++ b/Backend/README.md
@@ -65,7 +65,8 @@
 
     php artisan test
     # oppure con coverage:
-    php artisan test --coverage📄 Documentazione
+    php artisan test --coverage
+📄 Documentazione
     Guida tecnica sviluppatori (README-dev)
 
     API Routes


### PR DESCRIPTION
## Summary
- tidy up README testing section by moving `Documentazione` heading

## Testing
- `composer validate --no-check-publish`
- `composer install --dry-run` *(fails: ext-sodium missing)*

------
https://chatgpt.com/codex/tasks/task_e_68821ac96a288324a6f99c6cb0e5632a