### PR TITLE
Refactor profile page components

### DIFF
--- a/Frontend-nextjs/app/(protected)/profilo/ProfilePage.tsx
+++ b/Frontend-nextjs/app/(protected)/profilo/ProfilePage.tsx
@@ -6,34 +6,10 @@
 
 import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-
-// -------------------------
-// Avatar disponibili (aggiungi le tue immagini)
-// -------------------------
-const AVATAR_CHOICES = [
-    "/images/avatars/avatar-1.svg",
-    "/images/avatars/avatar-2.svg",
-    "/images/avatars/avatar-3.svg",
-    "/images/avatars/avatar-4.svg",
-    "/images/avatars/avatar-5.svg",
-    "/images/avatars/avatar-6.svg",
-
-    // ...aggiungi altri se ne metti altri!
-];
-
-// -------------------------
-// Mock dati utente (da sostituire con fetch API)
-// -------------------------
-const MOCK_USER = {
-    name: "Mario",
-    surname: "Rossi",
-    username: "mario.rossi",
-    email: "mario.rossi@email.com",
-    theme: "solarized",
-    avatar: AVATAR_CHOICES[0], // default primo avatar
-};
-
-type UserType = typeof MOCK_USER;
+import ProfileRow from "./components/ProfileRow";
+import AvatarPickerModal from "./components/AvatarPickerModal";
+import { AVATAR_CHOICES } from "./components/constants";
+import { DEFAULT_USER, UserType } from "./components/types";
 
 // ======================================================
 // Componente principale
@@ -42,7 +18,7 @@ export default function ProfilePage() {
     // -----------------------------------
     // Stato dati utente e UI
     // -----------------------------------
-    const [user, setUser] = useState<UserType>(MOCK_USER);
+    const [user, setUser] = useState<UserType>(DEFAULT_USER);
     const [editing, setEditing] = useState<{ [K in keyof UserType]?: boolean }>({});
     const [showPicker, setShowPicker] = useState(false);
 
@@ -185,174 +161,5 @@ export default function ProfilePage() {
                 )}
             </AnimatePresence>
         </div>
-    );
-}
-
-// ======================================================
-// ProfileRow — Riga editabile profilo utente
-// ======================================================
-type RowProps = {
-    label: string;
-    value: string;
-    editing?: boolean;
-    onEdit: () => void;
-    onChange: (v: string) => void;
-    onSave: () => void;
-    type?: "text" | "select";
-    options?: { value: string; label: string }[];
-};
-
-function ProfileRow({ label, value, editing, onEdit, onChange, onSave, type = "text", options }: RowProps) {
-    return (
-        <div
-            className="flex items-center px-3 py-3 gap-4 group transition-all"
-            style={{
-                background: "transparent",
-                borderBottom: "1px solid hsl(var(--c-primary-border, 205 66% 49% / 0.08))",
-            }}
-        >
-            <div className="w-28 font-medium text-sm" style={{ color: "hsl(var(--c-text-secondary, 197 13% 45%))" }}>
-                {label}
-            </div>
-            <div className="flex-1">
-                {editing ? (
-                    type === "select" ? (
-                        <select
-                            className="px-2 py-1 rounded border text-sm"
-                            style={{
-                                background: "hsl(var(--c-bg, 44 81% 94%))",
-                                borderColor: "hsl(var(--c-primary-border, 205 66% 49% / 0.16))",
-                                color: "hsl(var(--c-text, 193 14% 40%))",
-                            }}
-                            value={value}
-                            onChange={(e) => onChange(e.target.value)}
-                        >
-                            {options?.map((opt) => (
-                                <option key={opt.value} value={opt.value}>
-                                    {opt.label}
-                                </option>
-                            ))}
-                        </select>
-                    ) : (
-                        <input
-                            className="px-2 py-1 rounded border text-sm"
-                            style={{
-                                background: "hsl(var(--c-bg, 44 81% 94%))",
-                                borderColor: "hsl(var(--c-primary-border, 205 66% 49% / 0.16))",
-                                color: "hsl(var(--c-text, 193 14% 40%))",
-                            }}
-                            value={value}
-                            onChange={(e) => onChange(e.target.value)}
-                        />
-                    )
-                ) : (
-                    <span style={{ color: "hsl(var(--c-text, 193 14% 40%))" }}>{value}</span>
-                )}
-            </div>
-            <div>
-                {editing ? (
-                    <button
-                        className="ml-2 px-2 py-1 rounded font-semibold shadow text-xs transition"
-                        style={{
-                            background: "hsl(var(--c-primary, 205 66% 49%))",
-                            color: "hsl(var(--c-bg, 44 81% 94%))",
-                        }}
-                        onClick={onSave}
-                    >
-                        Salva
-                    </button>
-                ) : (
-                    <button
-                        className="opacity-70 group-hover:opacity-100 px-2 py-1 rounded font-semibold text-xs transition"
-                        style={{
-                            background: "hsl(var(--c-secondary, 220 15% 48%))",
-                            color: "hsl(var(--c-bg, 44 81% 94%))",
-                        }}
-                        onClick={onEdit}
-                    >
-                        Modifica
-                    </button>
-                )}
-            </div>
-        </div>
-    );
-}
-
-// ======================================================
-// AvatarPickerModal — Modale scelta avatar
-// ======================================================
-function AvatarPickerModal({
-    avatarList,
-    selected,
-    onSelect,
-    onClose,
-}: {
-    avatarList: string[];
-    selected: string;
-    onSelect: (val: string) => void;
-    onClose: () => void;
-}) {
-    return (
-        <motion.div
-            className="fixed inset-0 flex items-center justify-center z-50"
-            style={{
-                background: "hsl(var(--c-bg-glass, 44 36% 88% / 0.8))",
-                backdropFilter: "blur(4px)",
-            }}
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-        >
-            <motion.div
-                className="relative rounded-2xl p-5 flex flex-col items-center max-w-xs w-full"
-                style={{
-                    background: "hsl(var(--modal-bg, 44 36% 88%))",
-                    border: "1.5px solid hsl(var(--modal-border, 205 66% 49% / 0.16))",
-                    color: "hsl(var(--modal-text, 193 14% 40%))",
-                    boxShadow: "0 6px 32px 0 hsl(var(--c-primary-shadow, 205 66% 49% / 0.09))",
-                }}
-                initial={{ scale: 0.8, opacity: 0 }}
-                animate={{ scale: 1, opacity: 1 }}
-                exit={{ scale: 0.8, opacity: 0 }}
-                transition={{ type: "spring", stiffness: 400, damping: 30 }}
-            >
-                <div className="mb-2 text-base font-bold">Scegli il tuo avatar</div>
-                <div className="grid grid-cols-3 gap-4 my-3">
-                    {avatarList.map((src) => (
-                        <button
-                            key={src}
-                            type="button"
-                            className={`rounded-full border-2 transition-all duration-100 ${
-                                selected === src
-                                    ? "border-primary ring-2 ring-primary scale-110"
-                                    : "border-transparent opacity-80 hover:opacity-100"
-                            }`}
-                            onClick={() => onSelect(src)}
-                        >
-                            <img src={src} alt="" className="w-16 h-16 rounded-full object-cover" />
-                        </button>
-                    ))}
-                </div>
-                <button
-                    className="px-3 py-1 mt-2 rounded font-semibold text-xs transition"
-                    style={{
-                        background: "hsl(var(--c-secondary, 220 15% 48%))",
-                        color: "hsl(var(--c-bg, 44 81% 94%))",
-                    }}
-                    onClick={onClose}
-                >
-                    Annulla
-                </button>
-                <button
-                    className="absolute top-2 right-2 font-bold text-xl"
-                    style={{ color: "hsl(var(--modal-title, 205 66% 49%))" }}
-                    onClick={onClose}
-                    aria-label="Chiudi"
-                    tabIndex={-1}
-                >
-                    ×
-                </button>
-            </motion.div>
-        </motion.div>
     );
 }

--- a/Frontend-nextjs/app/(protected)/profilo/components/AvatarPickerModal.tsx
+++ b/Frontend-nextjs/app/(protected)/profilo/components/AvatarPickerModal.tsx
@@ -1,0 +1,72 @@
+import { motion } from "framer-motion";
+
+interface AvatarPickerModalProps {
+    avatarList: string[];
+    selected: string;
+    onSelect: (val: string) => void;
+    onClose: () => void;
+}
+
+export default function AvatarPickerModal({ avatarList, selected, onSelect, onClose }: AvatarPickerModalProps) {
+    return (
+        <motion.div
+            className="fixed inset-0 flex items-center justify-center z-50"
+            style={{
+                background: "hsl(var(--c-bg-glass, 44 36% 88% / 0.8))",
+                backdropFilter: "blur(4px)",
+            }}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+        >
+            <motion.div
+                className="relative rounded-2xl p-5 flex flex-col items-center max-w-xs w-full"
+                style={{
+                    background: "hsl(var(--modal-bg, 44 36% 88%))",
+                    border: "1.5px solid hsl(var(--modal-border, 205 66% 49% / 0.16))",
+                    color: "hsl(var(--modal-text, 193 14% 40%))",
+                    boxShadow: "0 6px 32px 0 hsl(var(--c-primary-shadow, 205 66% 49% / 0.09))",
+                }}
+                initial={{ scale: 0.8, opacity: 0 }}
+                animate={{ scale: 1, opacity: 1 }}
+                exit={{ scale: 0.8, opacity: 0 }}
+                transition={{ type: "spring", stiffness: 400, damping: 30 }}
+            >
+                <div className="mb-2 text-base font-bold">Scegli il tuo avatar</div>
+                <div className="grid grid-cols-3 gap-4 my-3">
+                    {avatarList.map((src) => (
+                        <button
+                            key={src}
+                            type="button"
+                            className={`rounded-full border-2 transition-all duration-100 ${
+                                selected === src ? "border-primary ring-2 ring-primary scale-110" : "border-transparent opacity-80 hover:opacity-100"
+                            }`}
+                            onClick={() => onSelect(src)}
+                        >
+                            <img src={src} alt="" className="w-16 h-16 rounded-full object-cover" />
+                        </button>
+                    ))}
+                </div>
+                <button
+                    className="px-3 py-1 mt-2 rounded font-semibold text-xs transition"
+                    style={{
+                        background: "hsl(var(--c-secondary, 220 15% 48%))",
+                        color: "hsl(var(--c-bg, 44 81% 94%))",
+                    }}
+                    onClick={onClose}
+                >
+                    Annulla
+                </button>
+                <button
+                    className="absolute top-2 right-2 font-bold text-xl"
+                    style={{ color: "hsl(var(--modal-title, 205 66% 49%))" }}
+                    onClick={onClose}
+                    aria-label="Chiudi"
+                    tabIndex={-1}
+                >
+                    ×
+                </button>
+            </motion.div>
+        </motion.div>
+    );
+}

--- a/Frontend-nextjs/app/(protected)/profilo/components/ProfileRow.tsx
+++ b/Frontend-nextjs/app/(protected)/profilo/components/ProfileRow.tsx
@@ -1,0 +1,77 @@
+import { RowProps } from "./types";
+
+export default function ProfileRow({ label, value, editing, onEdit, onChange, onSave, type = "text", options }: RowProps) {
+    return (
+        <div
+            className="flex items-center px-3 py-3 gap-4 group transition-all"
+            style={{
+                background: "transparent",
+                borderBottom: "1px solid hsl(var(--c-primary-border, 205 66% 49% / 0.08))",
+            }}
+        >
+            <div className="w-28 font-medium text-sm" style={{ color: "hsl(var(--c-text-secondary, 197 13% 45%))" }}>
+                {label}
+            </div>
+            <div className="flex-1">
+                {editing ? (
+                    type === "select" ? (
+                        <select
+                            className="px-2 py-1 rounded border text-sm"
+                            style={{
+                                background: "hsl(var(--c-bg, 44 81% 94%))",
+                                borderColor: "hsl(var(--c-primary-border, 205 66% 49% / 0.16))",
+                                color: "hsl(var(--c-text, 193 14% 40%))",
+                            }}
+                            value={value}
+                            onChange={(e) => onChange(e.target.value)}
+                        >
+                            {options?.map((opt) => (
+                                <option key={opt.value} value={opt.value}>
+                                    {opt.label}
+                                </option>
+                            ))}
+                        </select>
+                    ) : (
+                        <input
+                            className="px-2 py-1 rounded border text-sm"
+                            style={{
+                                background: "hsl(var(--c-bg, 44 81% 94%))",
+                                borderColor: "hsl(var(--c-primary-border, 205 66% 49% / 0.16))",
+                                color: "hsl(var(--c-text, 193 14% 40%))",
+                            }}
+                            value={value}
+                            onChange={(e) => onChange(e.target.value)}
+                        />
+                    )
+                ) : (
+                    <span style={{ color: "hsl(var(--c-text, 193 14% 40%))" }}>{value}</span>
+                )}
+            </div>
+            <div>
+                {editing ? (
+                    <button
+                        className="ml-2 px-2 py-1 rounded font-semibold shadow text-xs transition"
+                        style={{
+                            background: "hsl(var(--c-primary, 205 66% 49%))",
+                            color: "hsl(var(--c-bg, 44 81% 94%))",
+                        }}
+                        onClick={onSave}
+                    >
+                        Salva
+                    </button>
+                ) : (
+                    <button
+                        className="opacity-70 group-hover:opacity-100 px-2 py-1 rounded font-semibold text-xs transition"
+                        style={{
+                            background: "hsl(var(--c-secondary, 220 15% 48%))",
+                            color: "hsl(var(--c-bg, 44 81% 94%))",
+                        }}
+                        onClick={onEdit}
+                    >
+                        Modifica
+                    </button>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/Frontend-nextjs/app/(protected)/profilo/components/constants.ts
+++ b/Frontend-nextjs/app/(protected)/profilo/components/constants.ts
@@ -1,0 +1,9 @@
+export const AVATAR_CHOICES = [
+    "/images/avatars/avatar-1.svg",
+    "/images/avatars/avatar-2.svg",
+    "/images/avatars/avatar-3.svg",
+    "/images/avatars/avatar-4.svg",
+    "/images/avatars/avatar-5.svg",
+    "/images/avatars/avatar-6.svg",
+    // ...aggiungi altri se ne metti altri!
+];

--- a/Frontend-nextjs/app/(protected)/profilo/components/types.ts
+++ b/Frontend-nextjs/app/(protected)/profilo/components/types.ts
@@ -1,0 +1,30 @@
+import { AVATAR_CHOICES } from "./constants";
+
+export type UserType = {
+    name: string;
+    surname: string;
+    username: string;
+    email: string;
+    theme: string;
+    avatar: string;
+};
+
+export const DEFAULT_USER: UserType = {
+    name: "Mario",
+    surname: "Rossi",
+    username: "mario.rossi",
+    email: "mario.rossi@email.com",
+    theme: "solarized",
+    avatar: AVATAR_CHOICES[0],
+};
+
+export type RowProps = {
+    label: string;
+    value: string;
+    editing?: boolean;
+    onEdit: () => void;
+    onChange: (v: string) => void;
+    onSave: () => void;
+    type?: "text" | "select";
+    options?: { value: string; label: string }[];
+};


### PR DESCRIPTION
## Summary
- extract profile components into their own files
- create constants and types for profile page
- simplify `ProfilePage.tsx` to use the new components

## Testing
- `npm install`
- `npm run build` *(fails: Module not found in another folder)*

------
https://chatgpt.com/codex/tasks/task_e_68822c7252fc8324b50db9989ea55e78