### PR TITLE
Organize profile types

### DIFF
--- a/Frontend-nextjs/app/(protected)/profilo/ProfilePage.tsx
+++ b/Frontend-nextjs/app/(protected)/profilo/ProfilePage.tsx
@@ -9,7 +9,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import ProfileRow from "./components/ProfileRow";
 import AvatarPickerModal from "./components/AvatarPickerModal";
 import { AVATAR_CHOICES } from "./components/constants";
-import { DEFAULT_USER, UserType } from "./components/types";
+import { DEFAULT_USER, UserType } from "@/types/types/user";
 
 // ======================================================
 // Componente principale

--- a/Frontend-nextjs/app/(protected)/profilo/components/ProfileRow.tsx
+++ b/Frontend-nextjs/app/(protected)/profilo/components/ProfileRow.tsx
@@ -1,4 +1,4 @@
-import { RowProps } from "./types";
+import { RowProps } from "@/types/profilo/row";
 
 export default function ProfileRow({ label, value, editing, onEdit, onChange, onSave, type = "text", options }: RowProps) {
     return (

--- a/Frontend-nextjs/types/index.ts
+++ b/Frontend-nextjs/types/index.ts
@@ -1,5 +1,6 @@
 export * from "./types/sidebar";
-export * from "./types/darkmode";
 export * from "./types/transaction";
 export * from "./types/category";
 export * from "./types/ricorrenza";
+export * from "./types/user";
+export * from "./profilo/row";

--- a/Frontend-nextjs/types/profilo/row.ts
+++ b/Frontend-nextjs/types/profilo/row.ts
@@ -1,0 +1,10 @@
+export type RowProps = {
+    label: string;
+    value: string;
+    editing?: boolean;
+    onEdit: () => void;
+    onChange: (v: string) => void;
+    onSave: () => void;
+    type?: "text" | "select";
+    options?: { value: string; label: string }[];
+};

--- a/Frontend-nextjs/types/types/user.ts
+++ b/Frontend-nextjs/types/types/user.ts
@@ -1,4 +1,4 @@
-import { AVATAR_CHOICES } from "./constants";
+import { AVATAR_CHOICES } from "@/app/(protected)/profilo/components/constants";
 
 export type UserType = {
     name: string;
@@ -16,15 +16,4 @@ export const DEFAULT_USER: UserType = {
     email: "mario.rossi@email.com",
     theme: "solarized",
     avatar: AVATAR_CHOICES[0],
-};
-
-export type RowProps = {
-    label: string;
-    value: string;
-    editing?: boolean;
-    onEdit: () => void;
-    onChange: (v: string) => void;
-    onSave: () => void;
-    type?: "text" | "select";
-    options?: { value: string; label: string }[];
 };


### PR DESCRIPTION
## Summary
- centralize `UserType` and `DEFAULT_USER` in `types/types/user.ts`
- isolate `RowProps` in `types/profilo/row.ts`
- update imports in profile components
- export new types from `types/index.ts`

## Testing
- `npm run build` *(fails: Module not found)*
- `npx tsc --noEmit` *(fails: many missing declarations)*

------
https://chatgpt.com/codex/tasks/task_e_688232344c988324bac13f713e9ca2f1