### PR TITLE
Update docs for Frontend-nextjs path

### DIFF
--- a/Frontend-nextjs/README.md
+++ b/Frontend-nextjs/README.md
@@ -40,10 +40,10 @@ Frontend **Next.js**/React per Synapsi Finance — visualizza, filtra e gestisci
 
 ## ⚡ Avvio rapido
 
-1. **Spostati nella cartella frontend**
+1. **Spostati nella cartella Frontend-nextjs**
 
     ```bash
-    cd frontend
+    cd Frontend-nextjs
     ```
 
 2. **Installa le dipendenze**

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Monorepo con **Laravel API backend** + **Next.js frontend**
 
 /
 ├── backend/ # API RESTful Laravel 12.x (gestione dati e logica di business)
-├── frontend/ # Web app Next.js 15 (dashboard, UI, autenticazione)
+├── Frontend-nextjs/ # Web app Next.js 15 (dashboard, UI, autenticazione)
 ├── docs/ # Documentazione tecnica e guide
 ├── LICENSE
 ├── README.md # (questo file)
@@ -41,7 +41,7 @@ Monorepo con **Laravel API backend** + **Next.js frontend**
 3. **Setup Frontend**
 
     ```bash
-    cd frontend
+    cd Frontend-nextjs
     npm install
     cp .env.example .env
     # Configura API_URL e variabili necessarie
@@ -54,7 +54,7 @@ Monorepo con **Laravel API backend** + **Next.js frontend**
 
 Per la dashboard e l’interfaccia utente consulta il README del frontend:
 
--   [🌈 Synapsi Finance — Frontend Web (Next.js)](../Frontend-nextjs/README.md)
+-   [🌈 Synapsi Finance — Frontend Web (Next.js)](Frontend-nextjs/README.md)
 
 ## 📸 Screenshot
 


### PR DESCRIPTION
## Summary
- update tree reference for Frontend folder
- adjust setup path and docs links
- update frontend README quick-start instructions

## Testing
- `composer install --no-interaction --no-progress --ignore-platform-req=ext-sodium`
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68823ac3f87883249386f4263e502103