### PR TITLE
Organize page-specific types

### DIFF
--- a/Frontend-nextjs/app/(protected)/transazioni/components/list/TransactionTable.tsx
+++ b/Frontend-nextjs/app/(protected)/transazioni/components/list/TransactionTable.tsx
@@ -9,7 +9,7 @@ import { useReactTable, getCoreRowModel, flexRender, ColumnResizeMode, Row } fro
 import { Transaction } from "@/types/types/transaction";
 import { addMonthGroup } from "./table/utils";
 import { getColumnsWithSelection } from "./table/columns";
-import { TransactionWithGroup } from "./table/types";
+import { TransactionWithGroup } from "@/types/transazioni";
 import TableRow from "./table/TableRow";
 import MonthDividerRow from "./table/MonthDividerRow";
 import YearDividerRow from "./table/YearDividerRow";

--- a/Frontend-nextjs/app/(protected)/transazioni/components/list/table/TableRow.tsx
+++ b/Frontend-nextjs/app/(protected)/transazioni/components/list/table/TableRow.tsx
@@ -3,7 +3,7 @@
 // ╚══════════════════════════════════════════════════════╝
 
 import { Row, flexRender } from "@tanstack/react-table";
-import { TransactionWithGroup } from "./types";
+import { TransactionWithGroup } from "@/types/transazioni";
 import clsx from "clsx";
 import { useSelection } from "../../../../../../context/contexts/SelectionContext";
 

--- a/Frontend-nextjs/app/(protected)/transazioni/components/list/table/columns.tsx
+++ b/Frontend-nextjs/app/(protected)/transazioni/components/list/table/columns.tsx
@@ -5,7 +5,7 @@
 import { ArrowDown, ArrowUp } from "lucide-react";
 import clsx from "clsx";
 import { ColumnDef, Row } from "@tanstack/react-table";
-import { TransactionWithGroup } from "./types";
+import { TransactionWithGroup } from "@/types/transazioni";
 import { hexToHSL } from "./utils"; // Importa la funzione dal tuo utils
 
 // ============================

--- a/Frontend-nextjs/app/(protected)/transazioni/components/list/table/utils.ts
+++ b/Frontend-nextjs/app/(protected)/transazioni/components/list/table/utils.ts
@@ -1,6 +1,6 @@
 // utils.ts
 import { Transaction } from "@/types/types/transaction";
-import { TransactionWithGroup } from "./types";
+import { TransactionWithGroup } from "@/types/transazioni";
 
 // Aggiunge monthGroup (YYYY-MM) a ogni transazione
 export function addMonthGroup(transactions: Transaction[]): TransactionWithGroup[] {

--- a/Frontend-nextjs/types/index.ts
+++ b/Frontend-nextjs/types/index.ts
@@ -4,3 +4,4 @@ export * from "./types/category";
 export * from "./types/ricorrenza";
 export * from "./types/user";
 export * from "./profilo/row";
+export * from "./transazioni";

--- a/Frontend-nextjs/types/transazioni/index.ts
+++ b/Frontend-nextjs/types/transazioni/index.ts
@@ -1,4 +1,4 @@
-// types.ts
+// Tipi specifici per la pagina Transazioni
 import { Transaction } from "@/types/types/transaction";
 
 // Estende Transaction con campo di raggruppamento


### PR DESCRIPTION
## Summary
- create `transazioni` types directory under `types`
- move `TransactionWithGroup` type there
- update imports to use centralized type path
- export from `types/index.ts`

## Testing
- `npm install`
- `npm run build` *(fails: Module not found)*

------
https://chatgpt.com/codex/tasks/task_e_68823d0d87e48324ac8dc61463de14e1