### PR TITLE
Allow avatar path selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,17 @@ Monorepo con **Laravel API backend** + **Next.js frontend**
 
 2. **Setup Backend**
 
-    Vedi la guida dettagliata: [`Backend/README.md`](Backend/README.md)
+    ```bash
+    cd Backend
+    composer install
+    cp .env.example .env
+    php artisan key:generate
+    php artisan migrate --seed
+    composer test
+    cd ..
+    ```
+
+    Per maggiori dettagli consulta [`Backend/README.md`](Backend/README.md)
 
 3. **Setup Frontend**
 


### PR DESCRIPTION
## Summary
- support predefined avatar paths
- expand avatar validation to allow file or path
- return all profile fields to frontend
- allow partial profile updates
- document composer install and test commands

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688276cc68f08324831ad4cf802158c3