### PR TITLE
Add theme sync with profile

### DIFF
--- a/Frontend-nextjs/app/(protected)/layout-components/Sidebar.tsx
+++ b/Frontend-nextjs/app/(protected)/layout-components/Sidebar.tsx
@@ -21,7 +21,7 @@ import {
     ListOrdered,
 } from "lucide-react";
 import { useSidebar } from "@/context/contexts/SidebarContext";
-import { useTheme } from "next-themes";
+import { useThemeContext } from "@/context/contexts/ThemeContext";
 import { useState } from "react";
 
 // ────────────────────────────────
@@ -51,8 +51,8 @@ export default function Sidebar() {
     const pathname = usePathname();
 
     // ========== Gestione temi ==========
-    const { resolvedTheme, theme, setTheme } = useTheme();
-    const isDark = resolvedTheme === "dark";
+    const { theme, setTheme } = useThemeContext();
+    const isDark = theme === "dark";
 
     // ========== Helper ==========
     const toggleMobile = () => setIsOpenMobile((p) => !p);

--- a/Frontend-nextjs/app/(protected)/profilo/ProfilePage.tsx
+++ b/Frontend-nextjs/app/(protected)/profilo/ProfilePage.tsx
@@ -11,12 +11,14 @@ import AvatarPickerModal from "./components/AvatarPickerModal";
 import { AVATAR_CHOICES } from "./components/constants";
 import { DEFAULT_USER, UserType } from "@/types/models/user";
 import { useUser } from "@/context/contexts/UserContext";
+import { useThemeContext } from "@/context/contexts/ThemeContext";
 
 // ======================================================
 // Componente principale
 // ======================================================
 export default function ProfilePage() {
     const { user, update } = useUser();
+    const { setTheme } = useThemeContext();
 
     // -----------------------------------
     // Stato UI e form locale
@@ -33,6 +35,9 @@ export default function ProfilePage() {
     const handleEdit = (field: keyof UserType) => setEditing({ ...editing, [field]: true });
     const handleChange = (field: keyof UserType, value: string) => setForm({ ...form, [field]: value });
     const handleSave = async (field: keyof UserType) => {
+        if (field === "theme") {
+            setTheme(form.theme, false);
+        }
         await update({ [field]: form[field] } as Partial<UserType>);
         setEditing({ ...editing, [field]: false });
     };

--- a/Frontend-nextjs/context/GlobalContextProvider.tsx
+++ b/Frontend-nextjs/context/GlobalContextProvider.tsx
@@ -10,26 +10,29 @@ import { SidebarProvider } from "./contexts/SidebarContext";
 import { SelectionProvider } from "./contexts/SelectionContext";
 import { RicorrenzeProvider } from "./contexts/RicorrenzeContext";
 import { UserProvider } from "./contexts/UserContext";
+import { ThemeContextProvider } from "./contexts/ThemeContext";
 
 export default function GlobalContextProvider({ children }: { children: ReactNode }) {
     return (
         <SessionProvider>
             <UserProvider>
                 <ThemeProvider
-                attribute="class" // <--- Usa la classe "dark" su <html>
-                defaultTheme="system" // system = usa impostazione sistema
-                enableSystem
-                storageKey="theme" // key in localStorage
-            >
-                    <CategoriesProvider>
-                        <TransactionsProvider>
-                            <RicorrenzeProvider>
-                                <SelectionProvider>
-                                    <SidebarProvider>{children}</SidebarProvider>
-                                </SelectionProvider>
-                            </RicorrenzeProvider>
-                        </TransactionsProvider>
-                    </CategoriesProvider>
+                    attribute="class" // <--- Usa la classe "dark" su <html>
+                    defaultTheme="system" // system = usa impostazione sistema
+                    enableSystem
+                    storageKey="theme" // key in localStorage
+                >
+                    <ThemeContextProvider>
+                        <CategoriesProvider>
+                            <TransactionsProvider>
+                                <RicorrenzeProvider>
+                                    <SelectionProvider>
+                                        <SidebarProvider>{children}</SidebarProvider>
+                                    </SelectionProvider>
+                                </RicorrenzeProvider>
+                            </TransactionsProvider>
+                        </CategoriesProvider>
+                    </ThemeContextProvider>
                 </ThemeProvider>
             </UserProvider>
         </SessionProvider>

--- a/Frontend-nextjs/context/contexts/ThemeContext.tsx
+++ b/Frontend-nextjs/context/contexts/ThemeContext.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
+import { useTheme } from "next-themes";
+import { useUser } from "./UserContext";
+
+// ==============================
+// Tipizzazione
+// ==============================
+export type ThemeContextType = {
+    theme: string;
+    setTheme: (theme: string, persist?: boolean) => void;
+};
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+// ==============================
+// Provider
+// ==============================
+export function ThemeContextProvider({ children }: { children: React.ReactNode }) {
+    const { setTheme: setNextTheme } = useTheme();
+    const { user, update } = useUser();
+
+    const [theme, setThemeState] = useState("dark");
+
+    // Inizializza tema da profilo o localStorage
+    useEffect(() => {
+        if (typeof window === "undefined") return;
+        const stored = localStorage.getItem("theme");
+        const initial = user?.theme || stored || "dark";
+        setThemeState(initial);
+        setNextTheme(initial);
+    }, [user?.theme, setNextTheme]);
+
+    // Sincronizza tra tab
+    useEffect(() => {
+        const handler = (e: StorageEvent) => {
+            if (e.key === "theme" && e.newValue) {
+                setThemeState(e.newValue);
+                setNextTheme(e.newValue);
+            }
+        };
+        window.addEventListener("storage", handler);
+        return () => window.removeEventListener("storage", handler);
+    }, [setNextTheme]);
+
+    const handleSetTheme = (t: string, persist = true) => {
+        setThemeState(t);
+        setNextTheme(t);
+        if (persist) update({ theme: t });
+    };
+
+    return (
+        <ThemeContext.Provider value={{ theme, setTheme: handleSetTheme }}>
+            {children}
+        </ThemeContext.Provider>
+    );
+}
+
+export function useThemeContext() {
+    const ctx = useContext(ThemeContext);
+    if (!ctx) throw new Error("useThemeContext deve essere usato dentro <ThemeContextProvider>");
+    return ctx;
+}

--- a/Frontend-nextjs/types/models/user.ts
+++ b/Frontend-nextjs/types/models/user.ts
@@ -14,6 +14,6 @@ export const DEFAULT_USER: UserType = {
     surname: "Rossi",
     username: "mario.rossi",
     email: "mario.rossi@email.com",
-    theme: "solarized",
+    theme: "dark",
     avatar: AVATAR_CHOICES[0],
 };


### PR DESCRIPTION
## Summary
- add ThemeContext to sync theme with backend profile
- wrap ThemeContext in global provider
- update sidebar to use ThemeContext
- update profile page to change theme via context
- default profile theme is dark

## Testing
- `npm run build` *(fails: `authOptions` is not a valid Route export field)*

------
https://chatgpt.com/codex/tasks/task_e_6883a14d9fc88324a60e00ee57d7b0c7