### PR TITLE
Improve pending email UX

### DIFF
--- a/Backend/Modules/User/Routes/api.php
+++ b/Backend/Modules/User/Routes/api.php
@@ -30,6 +30,8 @@ Route::prefix('v1')->group(function () {
         Route::apiResource('users', UserController::class)->names('users');
         Route::get('profile', [ProfileController::class, 'show'])->name('profile.show');
         Route::put('profile', [ProfileController::class, 'update'])->name('profile.update');
+        Route::delete('profile/pending-email', [ProfileController::class, 'cancelPendingEmail'])->name('profile.pending-email.cancel');
+        Route::post('profile/pending-email/resend', [ProfileController::class, 'resendPendingEmail'])->name('profile.pending-email.resend');
         Route::delete('profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
         Route::get('dashboard', [DashboardController::class, 'index'])->name('dashboard.index');
     });

--- a/Frontend-nextjs/app/(protected)/profilo/ProfilePage.tsx
+++ b/Frontend-nextjs/app/(protected)/profilo/ProfilePage.tsx
@@ -13,6 +13,7 @@ import { AVATAR_CHOICES } from "./components/constants";
 import { DEFAULT_USER, UserType } from "@/types/models/user";
 import { useUser } from "@/context/contexts/UserContext";
 import { useThemeContext } from "@/context/contexts/ThemeContext";
+import PendingEmailNotice from "@/app/components/PendingEmailNotice";
 
 // ======================================================
 // Componente principale
@@ -54,6 +55,7 @@ export default function ProfilePage() {
     // -----------------------------------
     return (
         <div className="max-w-lg mx-auto space-y-6">
+            <PendingEmailNotice />
             {/* ========================================= */}
             {/* Avatar + Intestazione */}
             {/* ========================================= */}
@@ -143,6 +145,7 @@ export default function ProfilePage() {
                     onEdit={() => handleEdit("email")}
                     onChange={(v) => handleChange("email", v)}
                     onSave={() => handleSave("email")}
+                    disabled={!!user?.pending_email}
                 />
                 <ProfileRow
                     label="Tema"

--- a/Frontend-nextjs/app/(protected)/profilo/components/ProfileRow.tsx
+++ b/Frontend-nextjs/app/(protected)/profilo/components/ProfileRow.tsx
@@ -1,6 +1,6 @@
 import { RowProps } from "@/types/profilo/row";
 
-export default function ProfileRow({ label, value, editing, onEdit, onChange, onSave, type = "text", options }: RowProps) {
+export default function ProfileRow({ label, value, editing, onEdit, onChange, onSave, type = "text", options, disabled = false }: RowProps) {
     return (
         <div
             className="flex items-center px-3 py-3 gap-4 group transition-all"
@@ -65,8 +65,11 @@ export default function ProfileRow({ label, value, editing, onEdit, onChange, on
                         style={{
                             background: "hsl(var(--c-secondary, 220 15% 48%))",
                             color: "hsl(var(--c-bg, 44 81% 94%))",
+                            opacity: disabled ? 0.4 : undefined,
+                            pointerEvents: disabled ? "none" : undefined,
                         }}
                         onClick={onEdit}
+                        disabled={disabled}
                     >
                         Modifica
                     </button>

--- a/Frontend-nextjs/app/components/PendingEmailNotice.tsx
+++ b/Frontend-nextjs/app/components/PendingEmailNotice.tsx
@@ -3,12 +3,39 @@
 import { useUser } from "@/context/contexts/UserContext";
 
 export default function PendingEmailNotice() {
-    const { user } = useUser();
+    const { user, cancelPending, resendPending } = useUser();
     if (!user?.pending_email) return null;
 
+    const handleCancel = async () => {
+        if (confirm("Annullare la richiesta di cambio email?")) {
+            await cancelPending();
+        }
+    };
+
+    const handleResend = async () => {
+        await resendPending();
+    };
+
     return (
-        <div className="bg-yellow-100 border border-yellow-300 text-yellow-800 rounded p-2 mb-4 shadow">
-            In attesa di conferma per la nuova email: {user.pending_email}
+        <div className="bg-yellow-100 border border-yellow-300 text-yellow-800 rounded p-3 mb-4 shadow space-y-2">
+            <p>
+                Cambio email in attesa di conferma: <strong>{user.pending_email}</strong>
+            </p>
+            <p>Abbiamo inviato un link di conferma a questo indirizzo. Cliccalo per completare il cambio.</p>
+            <div className="flex gap-2">
+                <button
+                    className="px-2 py-1 rounded bg-red-500 text-white text-xs font-semibold"
+                    onClick={handleCancel}
+                >
+                    Annulla richiesta
+                </button>
+                <button
+                    className="px-2 py-1 rounded bg-blue-500 text-white text-xs font-semibold"
+                    onClick={handleResend}
+                >
+                    Reinvia email
+                </button>
+            </div>
         </div>
     );
 }

--- a/Frontend-nextjs/context/contexts/UserContext.tsx
+++ b/Frontend-nextjs/context/contexts/UserContext.tsx
@@ -2,7 +2,12 @@
 
 import { createContext, useContext, useEffect, useState } from "react";
 import type { UserType } from "@/types/models/user";
-import { fetchUserProfile, updateUserProfile } from "@/lib/api/userApi";
+import {
+    fetchUserProfile,
+    updateUserProfile,
+    cancelPendingEmail,
+    resendPendingEmail,
+} from "@/lib/api/userApi";
 import { useSession } from "next-auth/react";
 import { toast } from "sonner";
 
@@ -15,6 +20,8 @@ export type UserContextType = {
     error: string | null;
     refresh: () => void;
     update: (data: Partial<UserType>) => Promise<void>;
+    cancelPending: () => Promise<void>;
+    resendPending: () => Promise<void>;
 };
 
 const UserContext = createContext<UserContextType | undefined>(undefined);
@@ -65,8 +72,49 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
         }
     };
 
+    const cancelPending = async () => {
+        if (!token) return;
+        setLoading(true);
+        setError(null);
+        try {
+            const updated = await cancelPendingEmail(token);
+            setUser(updated);
+            toast.success("Richiesta annullata!");
+        } catch (e: any) {
+            setError(e.message || "Errore annullamento richiesta");
+            toast.error(e.message || "Errore annullamento richiesta");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const resendPending = async () => {
+        if (!token) return;
+        setLoading(true);
+        setError(null);
+        try {
+            await resendPendingEmail(token);
+            toast.success("Email di conferma inviata!");
+        } catch (e: any) {
+            setError(e.message || "Errore invio email");
+            toast.error(e.message || "Errore invio email");
+        } finally {
+            setLoading(false);
+        }
+    };
+
     return (
-        <UserContext.Provider value={{ user, loading, error, refresh: loadUser, update }}>
+        <UserContext.Provider
+            value={{
+                user,
+                loading,
+                error,
+                refresh: loadUser,
+                update,
+                cancelPending,
+                resendPending,
+            }}
+        >
             {children}
         </UserContext.Provider>
     );

--- a/Frontend-nextjs/lib/api/userApi.ts
+++ b/Frontend-nextjs/lib/api/userApi.ts
@@ -38,7 +38,40 @@ export async function updateUserProfile(
         },
         body: JSON.stringify(payload),
     });
-    if (!res.ok) throw new Error("Errore aggiornamento profilo");
-    const data = await res.json();
+    const data = await res.json().catch(() => null);
+    if (!res.ok) throw new Error(data?.message || "Errore aggiornamento profilo");
     return data.data || data;
+}
+
+// ==============================
+// DELETE pending email
+// ==============================
+export async function cancelPendingEmail(token: string): Promise<UserType> {
+    const res = await fetch(`${API_URL}/v1/profile/pending-email`, {
+        method: "DELETE",
+        headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+            Accept: "application/json",
+        },
+    });
+    const data = await res.json().catch(() => null);
+    if (!res.ok) throw new Error(data?.message || "Errore annullamento richiesta");
+    return data.data || data;
+}
+
+// ==============================
+// RESEND pending email link
+// ==============================
+export async function resendPendingEmail(token: string): Promise<void> {
+    const res = await fetch(`${API_URL}/v1/profile/pending-email/resend`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+            Accept: "application/json",
+        },
+    });
+    const data = await res.json().catch(() => null);
+    if (!res.ok) throw new Error(data?.message || "Errore invio email");
 }

--- a/Frontend-nextjs/types/profilo/row.ts
+++ b/Frontend-nextjs/types/profilo/row.ts
@@ -7,4 +7,5 @@ export type RowProps = {
     onSave: () => void;
     type?: "text" | "select";
     options?: { value: string; label: string }[];
+    disabled?: boolean;
 };


### PR DESCRIPTION
## Summary
- add pending-email management endpoints
- expose cancel/resend actions on frontend
- show banner with buttons when email change is pending
- disable email editing while a pending email exists

## Testing
- `composer test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6884e27b1014832489bbe27d771872ef