### PR TITLE
Force dark theme for auth pages

### DIFF
--- a/Frontend-nextjs/app/(auth)/login/page.tsx
+++ b/Frontend-nextjs/app/(auth)/login/page.tsx
@@ -11,6 +11,7 @@ import { handleLogin } from "@/lib/auth/handleLogin";
 import { handleTokenLogin } from "@/lib/auth/handleTokenLogin";
 import RegisterModal from "@/app/(auth)/login/form/modal/RegisterModal";
 import ForgotPasswordModal from "@/app/(auth)/login/form/modal/ForgotPasswordModal";
+import { useThemeContext } from "@/context/contexts/ThemeContext";
 
 // ==============================
 // PAGINA DI LOGIN CON REDIRECT E SFONDO
@@ -23,6 +24,16 @@ export default function LoginPage() {
     const [showReg, setShowReg] = useState(false);
     const [showForgot, setShowForgot] = useState(false);
     const [info, setInfo] = useState<string | null>(null);
+    const { theme, setTheme } = useThemeContext();
+
+    // ───── Forza tema dark durante la schermata di login ─────
+    useEffect(() => {
+        const prev = theme;
+        if (prev !== "dark") setTheme("dark", false);
+        return () => {
+            if (prev && prev !== "dark") setTheme(prev, false);
+        };
+    }, [theme, setTheme]);
 
     // ───── Redirect se già autenticato ─────
     useEffect(() => {

--- a/Frontend-nextjs/app/(auth)/reset-password/page.tsx
+++ b/Frontend-nextjs/app/(auth)/reset-password/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { useThemeContext } from "@/context/contexts/ThemeContext";
 import { Button } from "@/app/components/ui/Button";
 import PasswordInput from "../login/form/form-components/PasswordInput";
 import { handleResetPassword } from "@/lib/auth/handleResetPassword";
@@ -10,6 +11,16 @@ export default function ResetPasswordPage() {
   const router = useRouter();
   const [token, setToken] = useState("");
   const [email, setEmail] = useState("");
+  const { theme, setTheme } = useThemeContext();
+
+  // Forza il tema scuro su questa pagina
+  useEffect(() => {
+    const prev = theme;
+    if (prev !== "dark") setTheme("dark", false);
+    return () => {
+      if (prev && prev !== "dark") setTheme(prev, false);
+    };
+  }, [theme, setTheme]);
 
   useEffect(() => {
     if (typeof window !== "undefined") {


### PR DESCRIPTION
## Summary
- ensure login and password reset pages always use the dark theme

## Testing
- `npm run build`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6887214175a4832481d6994dcdd24691