### PR TITLE
Refine form UI components

### DIFF
--- a/Frontend-nextjs/app/components/ui/Button.tsx
+++ b/Frontend-nextjs/app/components/ui/Button.tsx
@@ -4,12 +4,15 @@ import { ButtonHTMLAttributes } from "react";
 type Props = ButtonHTMLAttributes<HTMLButtonElement>;
 
 export function Button(props: Props) {
+    const { className = "", style, disabled, ...rest } = props;
     return (
         <button
-            {...props}
-            className={`px-4 py-2 rounded-xl bg-primary text-bg font-semibold text-sm
-                        hover:opacity-90 transition shadow active:scale-95
-                        ${props.className || ""}`}
+            {...rest}
+            disabled={disabled}
+            className={`px-4 py-2 rounded-2xl font-semibold flex justify-center items-center gap-2 text-white shadow-md transition-all duration-200 bg-gradient-to-r from-primary to-primary-dark hover:shadow-2xl hover:-translate-y-0.5 active:scale-95 focus:outline-none focus:ring-2 focus:ring-primary/40 ${
+                disabled ? "opacity-70 cursor-not-allowed" : ""
+            } ${className}`}
+            style={{ background: "var(--c-primary-gradient)", ...style }}
         />
     );
 }

--- a/Frontend-nextjs/app/components/ui/Input.tsx
+++ b/Frontend-nextjs/app/components/ui/Input.tsx
@@ -7,7 +7,7 @@ export function Input(props: Props) {
     return (
         <input
             {...props}
-            className={`w-full px-3 py-2 rounded-xl border border-bg-elevate bg-bg text-text text-sm
+            className={`block mx-auto w-full px-3 py-2 rounded-xl border border-bg-elevate bg-bg text-text text-sm
                         focus:ring-2 focus:ring-primary focus:outline-none transition
                         ${props.className || ""}`}
         />

--- a/Frontend-nextjs/app/components/ui/Textarea.tsx
+++ b/Frontend-nextjs/app/components/ui/Textarea.tsx
@@ -8,7 +8,7 @@ export function Textarea(props: Props) {
         <textarea
             {...props}
             rows={3}
-            className={`w-full px-3 py-2 rounded-xl border border-bg-elevate bg-bg text-text text-sm
+            className={`block mx-auto w-full px-3 py-2 rounded-xl border border-bg-elevate bg-bg text-text text-sm
                         focus:ring-2 focus:ring-primary focus:outline-none transition
                         ${props.className || ""}`}
         />


### PR DESCRIPTION
## Summary
- center input and textarea fields by default
- restyle Button component with gradient background matching login style
- run Next.js build to verify

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6887272e65e88324a803eecd5e2bcbfb