### PR TITLE
Fix dark theme enforcement on auth pages

### DIFF
--- a/Frontend-nextjs/app/(auth)/login/page.tsx
+++ b/Frontend-nextjs/app/(auth)/login/page.tsx
@@ -33,7 +33,9 @@ export default function LoginPage() {
         return () => {
             if (prev && prev !== "dark") setTheme(prev, false);
         };
-    }, [theme, setTheme]);
+        // deliberately exclude `theme` from deps to avoid loop
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [setTheme]);
 
     // ───── Redirect se già autenticato ─────
     useEffect(() => {

--- a/Frontend-nextjs/app/(auth)/reset-password/page.tsx
+++ b/Frontend-nextjs/app/(auth)/reset-password/page.tsx
@@ -20,7 +20,9 @@ export default function ResetPasswordPage() {
     return () => {
       if (prev && prev !== "dark") setTheme(prev, false);
     };
-  }, [theme, setTheme]);
+    // intentionally exclude `theme` from deps to prevent toggle loop
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [setTheme]);
 
   useEffect(() => {
     if (typeof window !== "undefined") {


### PR DESCRIPTION
## Summary
- prevent infinite theme toggling on login and password reset pages by excluding the current theme from the effect dependency list
- build frontend and run backend tests

## Testing
- `npm run build`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68872b0f0194832499966d9f30e651d3