### PR TITLE
Fix dark theme enforcement on auth pages

### DIFF
--- a/Frontend-nextjs/app/(auth)/layout.tsx
+++ b/Frontend-nextjs/app/(auth)/layout.tsx
@@ -1,0 +1,10 @@
+/* app/(auth)/layout.tsx */
+import { ThemeProvider } from "next-themes";
+
+export const metadata = {
+    title: "Synapsy • Auth",
+};
+
+export default function AuthLayout({ children }: { children: React.ReactNode }) {
+    return <ThemeProvider forcedTheme="dark">{children}</ThemeProvider>;
+}

--- a/Frontend-nextjs/app/(auth)/login/page.tsx
+++ b/Frontend-nextjs/app/(auth)/login/page.tsx
@@ -11,7 +11,6 @@ import { handleLogin } from "@/lib/auth/handleLogin";
 import { handleTokenLogin } from "@/lib/auth/handleTokenLogin";
 import RegisterModal from "@/app/(auth)/login/form/modal/RegisterModal";
 import ForgotPasswordModal from "@/app/(auth)/login/form/modal/ForgotPasswordModal";
-import { useThemeContext } from "@/context/contexts/ThemeContext";
 
 // ==============================
 // PAGINA DI LOGIN CON REDIRECT E SFONDO
@@ -24,16 +23,6 @@ export default function LoginPage() {
     const [showReg, setShowReg] = useState(false);
     const [showForgot, setShowForgot] = useState(false);
     const [info, setInfo] = useState<string | null>(null);
-    const { theme, setTheme } = useThemeContext();
-
-    // ───── Forza tema dark durante la schermata di login ─────
-    useEffect(() => {
-        const prev = theme;
-        if (prev !== "dark") setTheme("dark", false);
-        return () => {
-            if (prev && prev !== "dark") setTheme(prev, false);
-        };
-    }, [theme, setTheme]);
 
     // ───── Redirect se già autenticato ─────
     useEffect(() => {

--- a/Frontend-nextjs/app/(auth)/reset-password/page.tsx
+++ b/Frontend-nextjs/app/(auth)/reset-password/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { useThemeContext } from "@/context/contexts/ThemeContext";
 import { Button } from "@/app/components/ui/Button";
 import PasswordInput from "../login/form/form-components/PasswordInput";
 import { handleResetPassword } from "@/lib/auth/handleResetPassword";
@@ -11,16 +10,6 @@ export default function ResetPasswordPage() {
   const router = useRouter();
   const [token, setToken] = useState("");
   const [email, setEmail] = useState("");
-  const { theme, setTheme } = useThemeContext();
-
-  // Forza il tema scuro su questa pagina
-  useEffect(() => {
-    const prev = theme;
-    if (prev !== "dark") setTheme("dark", false);
-    return () => {
-      if (prev && prev !== "dark") setTheme(prev, false);
-    };
-  }, [theme, setTheme]);
 
   useEffect(() => {
     if (typeof window !== "undefined") {


### PR DESCRIPTION
## Summary
- add an `(auth)` layout that forces `dark` theme
- drop theme toggling effect from login and reset password pages
- build frontend and run backend tests

## Testing
- `npm run build`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68872b0f0194832499966d9f30e651d3