### PR TITLE
Remove next-themes in favor of custom ThemeContext

### DIFF
--- a/Frontend-nextjs/app/(auth)/layout.tsx
+++ b/Frontend-nextjs/app/(auth)/layout.tsx
@@ -1,5 +1,4 @@
 /* app/(auth)/layout.tsx */
-import { ThemeProvider } from "next-themes";
 import Script from "next/script";
 
 export const metadata = {
@@ -13,10 +12,10 @@ export default function AuthLayout({ children }: { children: React.ReactNode }) 
                 id="force-dark"
                 strategy="beforeInteractive"
                 dangerouslySetInnerHTML={{
-                    __html: "try{localStorage.setItem('theme','dark');}catch{}",
+                    __html: "document.documentElement.className='dark';",
                 }}
             />
-            <ThemeProvider forcedTheme="dark">{children}</ThemeProvider>
+            {children}
         </>
     );
 }

--- a/Frontend-nextjs/app/layout.tsx
+++ b/Frontend-nextjs/app/layout.tsx
@@ -1,8 +1,6 @@
 /* app/layout.tsx */
 import "@/styles/globals.css";
-import { ThemeProvider } from "next-themes";
 import GlobalContextProvider from "@/context/GlobalContextProvider";
-import { availableThemes } from "@/lib/themeUtils";
 import { Toaster } from "sonner";
 
 export const metadata = {
@@ -12,43 +10,36 @@ export const metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
     return (
-        <html lang="it" suppressHydrationWarning>
+        <html lang="it" className="dark" suppressHydrationWarning>
             <body>
-                {/* Tema dinamico (dark/light) */}
-                <ThemeProvider
-                    attribute="data-theme"
-                    defaultTheme="system"
-                    enableSystem
-                    themes={availableThemes}
-                >
-                    {/* ==================================== */}
-                    {/*      TOASTER CENTRATO & STILOSO      */}
-                    {/* ==================================== */}
-                    <Toaster
-                        position="top-center"
-                        theme="system"
-                        richColors
-                        closeButton
-                        expand
-                        duration={6000} // millisecondi (es. 6 secondi)
-                        visibleToasts={4}
-                        className="font-semibold text-base tracking-wide"
-                        toastOptions={{
-                            style: {
-                                borderRadius: "1.2rem",
-                                boxShadow: "0 8px 32px 0 rgba(50,90,120,0.14)",
-                                border: "1.5px solid hsl(var(--c-border,220,15%,70%))",
-                                fontSize: "1rem",
-                                letterSpacing: "0.01em",
-                                maxWidth: "380px",
-                                minWidth: "280px",
-                                padding: "0.8rem 1rem",
-                            },
-                        }}
-                    />
-                    {/* Context globali (auth, sidebar ecc) */}
-                    <GlobalContextProvider>{children}</GlobalContextProvider>
-                </ThemeProvider>
+                {/* Toaster e contesti globali */}
+                {/* ==================================== */}
+                {/*      TOASTER CENTRATO & STILOSO      */}
+                {/* ==================================== */}
+                <Toaster
+                    position="top-center"
+                    theme="light"
+                    richColors
+                    closeButton
+                    expand
+                    duration={6000} // millisecondi (es. 6 secondi)
+                    visibleToasts={4}
+                    className="font-semibold text-base tracking-wide"
+                    toastOptions={{
+                        style: {
+                            borderRadius: "1.2rem",
+                            boxShadow: "0 8px 32px 0 rgba(50,90,120,0.14)",
+                            border: "1.5px solid hsl(var(--c-border,220,15%,70%))",
+                            fontSize: "1rem",
+                            letterSpacing: "0.01em",
+                            maxWidth: "380px",
+                            minWidth: "280px",
+                            padding: "0.8rem 1rem",
+                        },
+                    }}
+                />
+                {/* Context globali (auth, sidebar ecc) */}
+                <GlobalContextProvider>{children}</GlobalContextProvider>
             </body>
         </html>
     );

--- a/Frontend-nextjs/context/GlobalContextProvider.tsx
+++ b/Frontend-nextjs/context/GlobalContextProvider.tsx
@@ -2,7 +2,6 @@
 "use client";
 
 import { ReactNode } from "react";
-import { ThemeProvider } from "next-themes";
 import { SessionProvider } from "next-auth/react";
 import { CategoriesProvider } from "./contexts/CategoriesContext";
 import { TransactionsProvider } from "./contexts/TransactionsContext";
@@ -16,24 +15,17 @@ export default function GlobalContextProvider({ children }: { children: ReactNod
     return (
         <SessionProvider>
             <UserProvider>
-                <ThemeProvider
-                    attribute="class" // <--- Usa la classe "dark" su <html>
-                    defaultTheme="system" // system = usa impostazione sistema
-                    enableSystem
-                    storageKey="theme" // key in localStorage
-                >
-                    <ThemeContextProvider>
-                        <CategoriesProvider>
-                            <TransactionsProvider>
-                                <RicorrenzeProvider>
-                                    <SelectionProvider>
-                                        <SidebarProvider>{children}</SidebarProvider>
-                                    </SelectionProvider>
-                                </RicorrenzeProvider>
-                            </TransactionsProvider>
-                        </CategoriesProvider>
-                    </ThemeContextProvider>
-                </ThemeProvider>
+                <ThemeContextProvider>
+                    <CategoriesProvider>
+                        <TransactionsProvider>
+                            <RicorrenzeProvider>
+                                <SelectionProvider>
+                                    <SidebarProvider>{children}</SidebarProvider>
+                                </SelectionProvider>
+                            </RicorrenzeProvider>
+                        </TransactionsProvider>
+                    </CategoriesProvider>
+                </ThemeContextProvider>
             </UserProvider>
         </SessionProvider>
     );

--- a/Frontend-nextjs/context/contexts/ThemeContext.tsx
+++ b/Frontend-nextjs/context/contexts/ThemeContext.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { createContext, useContext, useEffect, useState } from "react";
-import { useTheme } from "next-themes";
 import { useUser } from "./UserContext";
 
 // ==============================
@@ -18,35 +17,26 @@ const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 // Provider
 // ==============================
 export function ThemeContextProvider({ children }: { children: React.ReactNode }) {
-    const { setTheme: setNextTheme } = useTheme();
     const { user, update } = useUser();
 
     const [theme, setThemeState] = useState("dark");
 
-    // Inizializza tema da profilo o localStorage
+    // Inizializza tema da profilo utente
     useEffect(() => {
         if (typeof window === "undefined") return;
-        const stored = localStorage.getItem("theme");
-        const initial = user?.theme || stored || "dark";
+        const initial = user?.theme || "dark";
         setThemeState(initial);
-        setNextTheme(initial);
-    }, [user?.theme, setNextTheme]);
+    }, [user?.theme]);
 
-    // Sincronizza tra tab
+    // Applica la classe al tag html
     useEffect(() => {
-        const handler = (e: StorageEvent) => {
-            if (e.key === "theme" && e.newValue) {
-                setThemeState(e.newValue);
-                setNextTheme(e.newValue);
-            }
-        };
-        window.addEventListener("storage", handler);
-        return () => window.removeEventListener("storage", handler);
-    }, [setNextTheme]);
+        if (typeof document !== "undefined") {
+            document.documentElement.className = theme;
+        }
+    }, [theme]);
 
     const handleSetTheme = (t: string, persist = true) => {
         setThemeState(t);
-        setNextTheme(t);
         if (persist) update({ theme: t });
     };
 

--- a/Frontend-nextjs/package-lock.json
+++ b/Frontend-nextjs/package-lock.json
@@ -17,7 +17,6 @@
                 "lucide-react": "^0.513.0",
                 "next": "^14.2.5",
                 "next-auth": "^4.24.11",
-                "next-themes": "^0.4.6",
                 "react": "^18.2.0",
                 "react-chartjs-2": "^5.3.0",
                 "react-dom": "^18.2.0",
@@ -1647,16 +1646,6 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/panva"
-            }
-        },
-        "node_modules/next-themes": {
-            "version": "0.4.6",
-            "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
-            "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
-            "license": "MIT",
-            "peerDependencies": {
-                "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
-                "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
             }
         },
         "node_modules/next/node_modules/postcss": {

--- a/Frontend-nextjs/package.json
+++ b/Frontend-nextjs/package.json
@@ -16,7 +16,6 @@
         "lucide-react": "^0.513.0",
         "next": "^14.2.5",
         "next-auth": "^4.24.11",
-        "next-themes": "^0.4.6",
         "react": "^18.2.0",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^18.2.0",


### PR DESCRIPTION
## Summary
- drop `next-themes` dependency
- manage theme with `ThemeContext` and apply class to `<html>`
- force dark theme for auth pages via script
- update global provider and root layout

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68873b884f6083248b1f1fa69c95b426