### PR TITLE
Ensure dark theme for auth forms

### DIFF
--- a/Frontend-nextjs/app/(auth)/layout.tsx
+++ b/Frontend-nextjs/app/(auth)/layout.tsx
@@ -12,7 +12,7 @@ export default function AuthLayout({ children }: { children: React.ReactNode }) 
                 id="force-dark"
                 strategy="beforeInteractive"
                 dangerouslySetInnerHTML={{
-                    __html: "document.documentElement.className='dark';",
+                    __html: "document.documentElement.className='dark';document.documentElement.setAttribute('data-theme','dark');",
                 }}
             />
             {children}


### PR DESCRIPTION
## Summary
- force dark theme data attribute in auth layout so registration and password reset remain dark

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6887406859e48324a0137c4a29b487b6