### PR TITLE
Improve theme persistence and profile UX

### DIFF
--- a/Frontend-nextjs/app/(protected)/profilo/ProfilePage.tsx
+++ b/Frontend-nextjs/app/(protected)/profilo/ProfilePage.tsx
@@ -7,7 +7,7 @@
 import { useEffect, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import ProfileRow from "./components/ProfileRow";
-import { availableThemes } from "@/lib/themeUtils";
+import ThemeSelectorRow from "./components/ThemeSelectorRow";
 import AvatarPickerModal from "./components/AvatarPickerModal";
 import { AVATAR_CHOICES } from "./components/constants";
 import { DEFAULT_USER, UserType } from "@/types/models/user";
@@ -147,18 +147,14 @@ export default function ProfilePage() {
                     onSave={() => handleSave("email")}
                     disabled={!!user?.pending_email}
                 />
-                <ProfileRow
-                    label="Tema"
+                <ThemeSelectorRow
                     value={form.theme}
                     editing={editing.theme}
                     onEdit={() => handleEdit("theme")}
-                    onChange={(v) => handleChange("theme", v)}
-                    onSave={() => handleSave("theme")}
-                    type="select"
-                    options={availableThemes.map((t) => ({
-                        value: t,
-                        label: t.charAt(0).toUpperCase() + t.slice(1),
-                    }))}
+                    onSave={(val) => {
+                        handleChange("theme", val);
+                        handleSave("theme");
+                    }}
                 />
             </div>
 

--- a/Frontend-nextjs/app/(protected)/profilo/components/ThemeSelectorRow.tsx
+++ b/Frontend-nextjs/app/(protected)/profilo/components/ThemeSelectorRow.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from "react";
+import { motion } from "framer-motion";
+import { useThemeContext } from "@/context/contexts/ThemeContext";
+import { availableThemes } from "@/lib/themeUtils";
+
+interface ThemeSelectorRowProps {
+    value: string;
+    editing: boolean | undefined;
+    onEdit: () => void;
+    onSave: (val: string) => void;
+}
+
+export default function ThemeSelectorRow({ value, editing, onEdit, onSave }: ThemeSelectorRowProps) {
+    const { setTheme } = useThemeContext();
+    const [selected, setSelected] = useState(value);
+
+    useEffect(() => {
+        setSelected(value);
+    }, [value]);
+
+    const handleHover = (t: string) => setTheme(t, false);
+    const handleLeave = () => setTheme(selected, false);
+
+    if (!editing) {
+        return (
+            <div
+                className="flex items-center px-3 py-3 gap-4 group"
+                style={{ borderBottom: "1px solid hsl(var(--c-primary-border, 205 66% 49% / 0.08))" }}
+            >
+                <div className="w-28 font-medium text-sm" style={{ color: "hsl(var(--c-text-secondary, 197 13% 45%))" }}>
+                    Tema
+                </div>
+                <div className="flex-1 capitalize" style={{ color: "hsl(var(--c-text, 193 14% 40%))" }}>{value}</div>
+                <div>
+                    <button
+                        className="opacity-70 group-hover:opacity-100 px-2 py-1 rounded font-semibold text-xs transition"
+                        style={{ background: "hsl(var(--c-secondary, 220 15% 48%))", color: "hsl(var(--c-bg, 44 81% 94%))" }}
+                        onClick={onEdit}
+                    >
+                        Modifica
+                    </button>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div
+            className="flex items-center px-3 py-3 gap-4"
+            style={{ borderBottom: "1px solid hsl(var(--c-primary-border, 205 66% 49% / 0.08))" }}
+        >
+            <div className="w-28 font-medium text-sm" style={{ color: "hsl(var(--c-text-secondary, 197 13% 45%))" }}>
+                Tema
+            </div>
+            <div className="flex-1 flex flex-wrap gap-2">
+                {availableThemes.map((t) => (
+                    <motion.button
+                        key={t}
+                        type="button"
+                        whileHover={{ scale: 1.05 }}
+                        className={`px-2 py-1 rounded border text-sm capitalize transition shadow-sm ${
+                            selected === t ? "ring-2 ring-primary border-primary" : "border-transparent opacity-80 hover:opacity-100"
+                        }`}
+                        onMouseEnter={() => handleHover(t)}
+                        onMouseLeave={handleLeave}
+                        onClick={() => setSelected(t)}
+                    >
+                        {t}
+                    </motion.button>
+                ))}
+            </div>
+            <div>
+                <button
+                    className="ml-2 px-2 py-1 rounded font-semibold shadow text-xs transition"
+                    style={{ background: "hsl(var(--c-primary, 205 66% 49%))", color: "hsl(var(--c-bg, 44 81% 94%))" }}
+                    onClick={() => onSave(selected)}
+                >
+                    Salva
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/Frontend-nextjs/app/components/PendingEmailNotice.tsx
+++ b/Frontend-nextjs/app/components/PendingEmailNotice.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useUser } from "@/context/contexts/UserContext";
+import { motion, AnimatePresence } from "framer-motion";
 
 export default function PendingEmailNotice() {
     const { user, cancelPending, resendPending } = useUser();
-    if (!user?.pending_email) return null;
 
     const handleCancel = async () => {
         if (confirm("Annullare la richiesta di cambio email?")) {
@@ -17,25 +17,36 @@ export default function PendingEmailNotice() {
     };
 
     return (
-        <div className="bg-yellow-100 border border-yellow-300 text-yellow-800 rounded p-3 mb-4 shadow space-y-2">
-            <p>
-                Cambio email in attesa di conferma: <strong>{user.pending_email}</strong>
-            </p>
-            <p>Abbiamo inviato un link di conferma a questo indirizzo. Cliccalo per completare il cambio.</p>
-            <div className="flex gap-2">
-                <button
-                    className="px-2 py-1 rounded bg-red-500 text-white text-xs font-semibold"
-                    onClick={handleCancel}
+        <AnimatePresence>
+            {user?.pending_email && (
+                <motion.div
+                    initial={{ opacity: 0, y: -10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: -10 }}
+                    className="mb-4 p-4 rounded-xl shadow-md border border-yellow-300 bg-gradient-to-r from-yellow-50 to-yellow-100 text-yellow-800 flex flex-col items-center text-center space-y-2"
                 >
-                    Annulla richiesta
-                </button>
-                <button
-                    className="px-2 py-1 rounded bg-blue-500 text-white text-xs font-semibold"
-                    onClick={handleResend}
-                >
-                    Reinvia email
-                </button>
-            </div>
-        </div>
+                    <p>
+                        Cambio email in attesa di conferma: <strong>{user.pending_email}</strong>
+                    </p>
+                    <p>Abbiamo inviato un link di conferma a questo indirizzo. Cliccalo per completare il cambio.</p>
+                    <div className="flex gap-2">
+                        <motion.button
+                            whileHover={{ scale: 1.05, opacity: 0.9 }}
+                            className="px-2 py-1 rounded shadow bg-red-500 text-white text-xs font-semibold"
+                            onClick={handleCancel}
+                        >
+                            Annulla richiesta
+                        </motion.button>
+                        <motion.button
+                            whileHover={{ scale: 1.05, opacity: 0.9 }}
+                            className="px-2 py-1 rounded shadow bg-blue-500 text-white text-xs font-semibold"
+                            onClick={handleResend}
+                        >
+                            Reinvia email
+                        </motion.button>
+                    </div>
+                </motion.div>
+            )}
+        </AnimatePresence>
     );
 }

--- a/Frontend-nextjs/app/layout.tsx
+++ b/Frontend-nextjs/app/layout.tsx
@@ -10,7 +10,7 @@ export const metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
     return (
-        <html lang="it" className="dark" suppressHydrationWarning>
+        <html lang="it" className="dark" data-theme="dark" suppressHydrationWarning>
             <body>
                 {/* Toaster e contesti globali */}
                 {/* ==================================== */}

--- a/Frontend-nextjs/context/contexts/ThemeContext.tsx
+++ b/Frontend-nextjs/context/contexts/ThemeContext.tsx
@@ -21,22 +21,32 @@ export function ThemeContextProvider({ children }: { children: React.ReactNode }
 
     const [theme, setThemeState] = useState("dark");
 
-    // Inizializza tema da profilo utente
+    // Inizializza tema da localStorage o profilo utente
     useEffect(() => {
         if (typeof window === "undefined") return;
-        const initial = user?.theme || "dark";
+        const stored = localStorage.getItem("theme");
+        const initial = stored || user?.theme || "dark";
         setThemeState(initial);
+    }, []);
+
+    // Aggiorna tema quando cambia quello salvato nel profilo
+    useEffect(() => {
+        if (user?.theme) setThemeState(user.theme);
     }, [user?.theme]);
 
-    // Applica la classe al tag html
+    // Applica classe e data-theme al tag html
     useEffect(() => {
         if (typeof document !== "undefined") {
             document.documentElement.className = theme;
+            document.documentElement.setAttribute("data-theme", theme);
         }
     }, [theme]);
 
     const handleSetTheme = (t: string, persist = true) => {
         setThemeState(t);
+        if (typeof window !== "undefined") {
+            localStorage.setItem("theme", t);
+        }
         if (persist) update({ theme: t });
     };
 


### PR DESCRIPTION
## Summary
- persist theme with localStorage and apply attribute
- add theme selector with preview on profile page
- style PendingEmailNotice with Tailwind and framer-motion
- default `data-theme` on html for SSR

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688747a979bc8324bc6a4e8bb96af8b4