### PR TITLE
Improve theme selector UX and unify theme names

### DIFF
--- a/Frontend-nextjs/app/(protected)/layout-components/Sidebar.tsx
+++ b/Frontend-nextjs/app/(protected)/layout-components/Sidebar.tsx
@@ -23,6 +23,7 @@ import {
 import { useSidebar } from "@/context/contexts/SidebarContext";
 import { useThemeContext } from "@/context/contexts/ThemeContext";
 import { useState } from "react";
+import { themeMeta } from "@/lib/themeUtils";
 
 // ────────────────────────────────
 // Configurazione navigazione
@@ -126,7 +127,7 @@ export default function Sidebar() {
                 <div className="p-4 border-t border-white/10 grid grid-cols-2 gap-2">
                     {["light", "dark", ...extraThemes].map((t) => {
                         const isActive = theme === t;
-                        const label = t.charAt(0).toUpperCase() + t.slice(1);
+                        const label = themeMeta[t as keyof typeof themeMeta].label;
                         const icon = t === "light" ? <Sun size={18} /> : t === "dark" ? <Moon size={18} /> : null;
 
                         return (

--- a/Frontend-nextjs/app/(protected)/profilo/ProfilePage.tsx
+++ b/Frontend-nextjs/app/(protected)/profilo/ProfilePage.tsx
@@ -60,7 +60,7 @@ export default function ProfilePage() {
             {/* Avatar + Intestazione */}
             {/* ========================================= */}
             <div
-                className="flex items-center gap-4 pb-2 border-b"
+                className="flex flex-col items-center text-center gap-3 pb-4 border-b"
                 style={{ borderColor: "hsl(var(--c-primary-border, 205 66% 49% / 0.16))" }}
             >
                 {/* ---- Avatar attuale (click per cambiare) ---- */}
@@ -94,10 +94,10 @@ export default function ProfilePage() {
                 </motion.div>
                 {/* ---- Titolo ---- */}
                 <div>
-                    <h1 className="text-xl font-bold" style={{ color: "hsl(var(--c-primary, 205 66% 49%))" }}>
+                    <h1 className="text-2xl font-bold text-primary drop-shadow-sm">
                         👤 Profilo
                     </h1>
-                    <p className="text-xs" style={{ color: "hsl(var(--c-text-secondary, 197 13% 45%))" }}>
+                    <p className="text-sm text-muted-foreground">
                         Modifica le informazioni del tuo account.
                     </p>
                 </div>
@@ -159,6 +159,7 @@ export default function ProfilePage() {
                         setForm((f) => ({ ...f, theme: val as any }));
                         setEditing((e) => ({ ...e, theme: false }));
                     }}
+                    onCancel={() => setEditing((e) => ({ ...e, theme: false }))}
                 />
             </div>
 

--- a/Frontend-nextjs/context/contexts/ThemeContext.tsx
+++ b/Frontend-nextjs/context/contexts/ThemeContext.tsx
@@ -2,7 +2,7 @@
 import { createContext, useContext, useEffect, useState } from "react";
 import { useUser } from "./UserContext";
 
-export type Theme = "light" | "dark" | "solarized";
+export type Theme = "light" | "dark" | "emerald" | "solarized";
 
 export type ThemeContextType = {
     theme: Theme;

--- a/Frontend-nextjs/lib/themeUtils.ts
+++ b/Frontend-nextjs/lib/themeUtils.ts
@@ -3,7 +3,7 @@ export const themeMeta = {
     light: { label: "Chiaro", color: "#faf6ee" },
     dark: { label: "Scuro", color: "#222934" },
     emerald: { label: "Smeraldo", color: "#4bffb1" },
-    solarized: { label: "Solarized", color: "#ffd671" },
+    solarized: { label: "Solarizzato", color: "#ffd671" },
 };
 
 export const availableThemes = Object.keys(themeMeta) as (keyof typeof themeMeta)[];


### PR DESCRIPTION
## Summary
- translate theme labels to Italian and expose them app-wide
- improve profile header layout
- enhance theme selector UX with cancel support, ESC & outside click
- show Italian labels for theme picker and sidebar
- add missing theme type `emerald`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68875e4d8be083248272b51efd65e094