### PR TITLE
Improve loaders and avatar

### DIFF
--- a/Frontend-nextjs/app/(auth)/login/loading.tsx
+++ b/Frontend-nextjs/app/(auth)/login/loading.tsx
@@ -1,8 +1,9 @@
 /* app/(auth)/loading.tsx */
 export default function AuthLoading() {
     return (
-        <div className="flex items-center justify-center min-h-screen bg-black/80 rounded">
+        <div className="flex flex-col items-center justify-center min-h-screen bg-black/80 rounded gap-2">
             <span className="h-8 w-8 border-4 border-white border-t-transparent rounded-full animate-spin" />
+            <span className="text-sm text-white">Sto caricando l'area login…</span>
         </div>
     );
 }

--- a/Frontend-nextjs/app/(protected)/categorie/list/CategoriesList.tsx
+++ b/Frontend-nextjs/app/(protected)/categorie/list/CategoriesList.tsx
@@ -9,6 +9,7 @@ import { useState } from "react";
 import DeleteCategoryModal from "../deleteModal/DeleteCategoryModal";
 import { Category } from "@/types";
 import CardCategories from "./cardCategories/CardCategories";
+import CategoriesListSkeleton from "./skeleton/CategoriesListSkeleton";
 
 // ============================
 // Componente principale
@@ -34,7 +35,16 @@ export default function CategoriesList() {
         }
     };
 
-    if (loading) return <div className="text-center p-4">Caricamento categorie...</div>;
+    if (loading) return (
+        <div className="px-2 md:px-6">
+            <div className="grid grid-cols-1 xl:grid-cols-2 gap-10">
+                <div className="hidden xl:block" />
+                <div className="space-y-2">
+                    <CategoriesListSkeleton />
+                </div>
+            </div>
+        </div>
+    );
     if (error) return <div className="text-center text-red-500 p-4">{error}</div>;
 
     return (

--- a/Frontend-nextjs/app/(protected)/categorie/list/skeleton/CategoriesListSkeleton.tsx
+++ b/Frontend-nextjs/app/(protected)/categorie/list/skeleton/CategoriesListSkeleton.tsx
@@ -1,0 +1,19 @@
+"use client";
+import Skeleton from "@/app/components/ui/Skeleton";
+
+export default function CategoriesListSkeleton() {
+    return (
+        <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 xl:grid-cols-3 gap-4">
+            {[...Array(6)].map((_, i) => (
+                <li key={i} className="p-4 rounded-2xl border border-bg-elevate bg-bg-elevate/60 shadow-md space-y-3">
+                    <Skeleton className="h-4 w-24" />
+                    <Skeleton className="h-6 w-32" />
+                    <div className="flex gap-2 mt-2">
+                        <Skeleton className="h-8 w-8 rounded-full" />
+                        <Skeleton className="h-8 w-8 rounded-full" />
+                    </div>
+                </li>
+            ))}
+        </ul>
+    );
+}

--- a/Frontend-nextjs/app/(protected)/layout-components/Header.tsx
+++ b/Frontend-nextjs/app/(protected)/layout-components/Header.tsx
@@ -60,7 +60,17 @@ export default function Header() {
                         "
                         title="Vai al profilo"
                     >
-                        <UserCircle size={18} className="text-primary" />
+                        {user?.avatar ? (
+                            <Image
+                                src={user.avatar}
+                                alt="Avatar utente"
+                                width={20}
+                                height={20}
+                                className="w-5 h-5 rounded-full object-cover"
+                            />
+                        ) : (
+                            <UserCircle size={18} className="text-primary" />
+                        )}
                         <span className="truncate">{username}</span>
                     </Link>
                 )}

--- a/Frontend-nextjs/app/(protected)/loading.tsx
+++ b/Frontend-nextjs/app/(protected)/loading.tsx
@@ -1,30 +1,29 @@
 "use client";
 
+import Skeleton from "@/app/components/ui/Skeleton";
+
 export default function ProtectedLoading() {
     return (
         <div className="flex h-screen">
             {/* ───── Sidebar skeleton ───── */}
             <aside className="hidden md:block w-56 bg-[rgb(24,24,24)] p-4 space-y-4">
                 {[...Array(6)].map((_, i) => (
-                    <div
-                        key={i}
-                        className="h-4 bg-[rgb(48,48,48)] rounded animate-pulse"
-                        style={{ animationDelay: `${i * 80}ms` }}
-                    />
+                    <Skeleton key={i} className="h-4" style={{ animationDelay: `${i * 80}ms` }} />
                 ))}
             </aside>
 
             {/* ───── Main area skeleton ───── */}
             <div className="flex-1 flex flex-col">
                 {/* Header fake */}
-                <header className="h-12 bg-[rgb(24,24,24)] flex items-center px-4">
-                    <div className="h-6 w-6 rounded-full bg-[rgb(48,48,48)] animate-pulse mr-4" />
-                    <div className="h-4 w-32 bg-[rgb(48,48,48)] rounded animate-pulse" />
+                <header className="h-12 bg-[rgb(24,24,24)] flex items-center px-4 gap-3">
+                    <Skeleton className="h-6 w-6 rounded-full" />
+                    <Skeleton className="h-4 w-32" />
                 </header>
 
                 {/* Contenuto centrale */}
-                <main className="flex-1 bg-[rgb(24,24,24)] flex items-center justify-center">
+                <main className="flex-1 bg-[rgb(24,24,24)] flex flex-col items-center justify-center gap-2">
                     <div className="h-8 w-8 border-4 border-[rgb(64,64,64)] border-t-transparent rounded-full animate-spin" />
+                    <span className="text-sm text-primary">Sto caricando la dashboard…</span>
                 </main>
             </div>
         </div>

--- a/Frontend-nextjs/app/(protected)/panoramica/components/skeleton/CalendarGridSkeleton.tsx
+++ b/Frontend-nextjs/app/(protected)/panoramica/components/skeleton/CalendarGridSkeleton.tsx
@@ -1,16 +1,15 @@
 // app/(protected)/panoramica/components/skeleton/CalendarGridSkeleton.tsx
 "use client";
 
+import Skeleton from "@/app/components/ui/Skeleton";
+
 export default function CalendarGridSkeleton() {
     return (
         <div className="grid grid-cols-7 gap-2 mb-6">
             {[...Array(30)].map((_, i) => (
-                <div
-                    key={i}
-                    className="h-20 bg-gray-800 rounded animate-pulse flex flex-col justify-center items-center"
-                >
-                    <div className="h-5 w-12 bg-gray-700 rounded mb-2" />
-                    <div className="h-3 w-8 bg-gray-700 rounded" />
+                <div key={i} className="h-20 rounded flex flex-col justify-center items-center">
+                    <Skeleton className="h-5 w-12 mb-2" />
+                    <Skeleton className="h-3 w-8" />
                 </div>
             ))}
         </div>

--- a/Frontend-nextjs/app/(protected)/ricorrenti/RicorrentiPage.tsx
+++ b/Frontend-nextjs/app/(protected)/ricorrenti/RicorrentiPage.tsx
@@ -13,6 +13,7 @@ import CardGraficoPagamenti from "./Card/CardGraficoPagamenti";
 import ListaRicorrenzePerFrequenza from "./liste/ListaRicorrenzePerFrequenza";
 import ListaProssimiPagamenti from "./liste/ListaProssimiPagamenti";
 import AreaGraficiRicorrenze from "./grafici/AreaGraficiRicorrenze";
+import RicorrentiPageSkeleton from "./skeleton/RicorrentiPageSkeleton";
 import {
     ordinaPerPrezzo,
     calcolaTotaliAnnuiPerFrequenza,
@@ -58,6 +59,8 @@ export default function RicorrentiPage() {
     // =======================================================
     // RENDER
     // =======================================================
+    if (loading) return <RicorrentiPageSkeleton />;
+
     return (
         <div className="space-y-8">
             {/* === Cards principali === */}
@@ -86,9 +89,6 @@ export default function RicorrentiPage() {
 
             {/* === Area grafici avanzati (opzionale) === */}
             <AreaGraficiRicorrenze />
-
-            {/* === Loading/errore === */}
-            {loading && <div className="text-center text-zinc-400 py-6">Caricamento ricorrenze...</div>}
         </div>
     );
 }

--- a/Frontend-nextjs/app/(protected)/ricorrenti/skeleton/RicorrentiPageSkeleton.tsx
+++ b/Frontend-nextjs/app/(protected)/ricorrenti/skeleton/RicorrentiPageSkeleton.tsx
@@ -1,0 +1,27 @@
+"use client";
+import Skeleton from "@/app/components/ui/Skeleton";
+
+export default function RicorrentiPageSkeleton() {
+    return (
+        <div className="space-y-8">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                {[...Array(2)].map((_, i) => (
+                    <div key={i} className="p-4 rounded-2xl border border-bg-elevate bg-bg-elevate/60 shadow-md space-y-4">
+                        <Skeleton className="h-5 w-1/2" />
+                        <Skeleton className="h-6 w-32" />
+                    </div>
+                ))}
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                {[...Array(2)].map((_, i) => (
+                    <div key={i} className="p-4 rounded-2xl border border-bg-elevate bg-bg-elevate/60 shadow-md space-y-3">
+                        <Skeleton className="h-5 w-1/3" />
+                        {[...Array(3)].map((_, j) => (
+                            <Skeleton key={j} className="h-4 w-full" />
+                        ))}
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/Frontend-nextjs/app/(protected)/transazioni/page.tsx
+++ b/Frontend-nextjs/app/(protected)/transazioni/page.tsx
@@ -4,12 +4,13 @@
 // Pagina principale lista transazioni — CRUD sync
 // ==============================================
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, Suspense } from "react";
 import { useTransactions } from "@/context/contexts/TransactionsContext";
 import { useCategories } from "@/context/contexts/CategoriesContext";
 import SelectionToolbar from "./components/SelectionToolbar";
-import TransactionsList from "./components/TransactionsList";
+import dynamic from "next/dynamic";
 import TransactionsListSkeleton from "./skeleton/TransactionsListSkeleton";
+const TransactionsList = dynamic(() => import("./components/TransactionsList"), { suspense: true });
 import TransactionDetailModal from "./modal/TransactionDetailModal";
 import NewTransactionButton from "../newTransaction/NewTransactionButton";
 import { Transaction } from "@/types/models/transaction";
@@ -112,14 +113,16 @@ export default function TransazioniPage() {
             {loading ? (
                 <TransactionsListSkeleton />
             ) : (
-                <>
-                    <SelectionToolbar onDeleteSelected={handleDeleteSelectedTransactions} />
-                    <TransactionsList
-                        transactions={transactions}
-                        onSelect={(tx) => setSelected(tx.id)}
-                        selectedId={selected}
-                    />
-                </>
+                <Suspense fallback={<TransactionsListSkeleton />}>
+                    <>
+                        <SelectionToolbar onDeleteSelected={handleDeleteSelectedTransactions} />
+                        <TransactionsList
+                            transactions={transactions}
+                            onSelect={(tx) => setSelected(tx.id)}
+                            selectedId={selected}
+                        />
+                    </>
+                </Suspense>
             )}
             {/* ===================== /Lista ===================== */}
 

--- a/Frontend-nextjs/app/(protected)/transazioni/skeleton/TransactionDetailModalSkeleton.tsx
+++ b/Frontend-nextjs/app/(protected)/transazioni/skeleton/TransactionDetailModalSkeleton.tsx
@@ -1,15 +1,17 @@
 // app/(protected)/panoramica/components/skeleton/TransactionDetailModalSkeleton.tsx
 "use client";
 
+import Skeleton from "@/app/components/ui/Skeleton";
+
 export default function TransactionDetailModalSkeleton() {
     return (
         <div className="fixed inset-0 flex items-center justify-center bg-black/50 z-50">
             <div className="bg-gray-900 p-8 rounded-2xl w-full max-w-md shadow-lg animate-pulse">
-                <div className="h-6 w-1/3 bg-gray-700 rounded mb-4" />
-                <div className="h-4 w-2/3 bg-gray-700 rounded mb-2" />
-                <div className="h-4 w-1/2 bg-gray-700 rounded mb-2" />
-                <div className="h-16 w-full bg-gray-800 rounded mb-6" />
-                <div className="h-10 w-full bg-gray-700 rounded" />
+                <Skeleton className="h-6 w-1/3 mb-4" />
+                <Skeleton className="h-4 w-2/3 mb-2" />
+                <Skeleton className="h-4 w-1/2 mb-2" />
+                <Skeleton className="h-16 w-full mb-6" />
+                <Skeleton className="h-10 w-full" />
             </div>
         </div>
     );

--- a/Frontend-nextjs/app/(protected)/transazioni/skeleton/TransactionsListSkeleton.tsx
+++ b/Frontend-nextjs/app/(protected)/transazioni/skeleton/TransactionsListSkeleton.tsx
@@ -1,13 +1,15 @@
 // app/(protected)/panoramica/components/skeleton/TransactionsListSkeleton.tsx
 "use client";
 
+import Skeleton from "@/app/components/ui/Skeleton";
+
 export default function TransactionsListSkeleton() {
     return (
         <ul className="space-y-1 mt-4">
             {[...Array(8)].map((_, i) => (
-                <li key={i} className="h-10 bg-gray-800 rounded-md animate-pulse flex items-center px-4">
-                    <div className="h-4 w-32 bg-gray-700 rounded mr-3" />
-                    <div className="h-4 w-16 bg-gray-700 rounded ml-auto" />
+                <li key={i} className="h-10 rounded-md flex items-center px-4">
+                    <Skeleton className="h-4 w-32 mr-3" />
+                    <Skeleton className="h-4 w-16 ml-auto" />
                 </li>
             ))}
         </ul>

--- a/Frontend-nextjs/app/components/ui/Skeleton.tsx
+++ b/Frontend-nextjs/app/components/ui/Skeleton.tsx
@@ -1,0 +1,7 @@
+"use client";
+import { HTMLAttributes } from "react";
+import clsx from "clsx";
+
+export default function Skeleton({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+    return <div className={clsx("bg-zinc-700/50 rounded animate-pulse", className)} {...props} />;
+}


### PR DESCRIPTION
## Summary
- add generic `Skeleton` component
- show user avatar in header when available
- unify protected and auth loading screens
- add skeletons for categories and recurring pages
- update existing skeletons to use the new component
- wrap transactions list with `Suspense` for async loading

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6887679c75fc8324b181807386d8433a