### PR TITLE
Add day transaction modal with preset date, improve logout style

### DIFF
--- a/Frontend-nextjs/app/(protected)/layout-components/Header.tsx
+++ b/Frontend-nextjs/app/(protected)/layout-components/Header.tsx
@@ -77,7 +77,7 @@ export default function Header() {
 
                 <button
                     onClick={handleLogout}
-                    className="flex items-center gap-1 p-2 rounded bg-white/10 text-white hover:text-red-400 transition"
+                    className="flex items-center gap-1 px-3 py-1 rounded-full bg-white/10 text-white hover:text-red-400 ring-1 ring-white/20 hover:ring-red-400 transition shadow-sm focus:outline-none focus:ring-2 focus:ring-red-400"
                 >
                     <span className="text-sm">Logout</span>
                     <LogOut size={16} />

--- a/Frontend-nextjs/app/(protected)/newTransaction/NewTransactionForm.tsx
+++ b/Frontend-nextjs/app/(protected)/newTransaction/NewTransactionForm.tsx
@@ -22,12 +22,12 @@ function cn(...classes: string[]) {
 // ╔═══════════════════════════════╗
 // ║      COMPONENTE PRINCIPALE    ║
 // ╚═══════════════════════════════╝
-export default function NewTransactionForm({ onSave, transaction, disabled, onChangeForm, onCancel }: NewTransactionFormProps) {
+export default function NewTransactionForm({ onSave, transaction, disabled, onChangeForm, onCancel, initialDate }: NewTransactionFormProps) {
     // ----- Stato form -----
     const [formData, setFormData] = useState<TransactionBase>({
         description: "",
         amount: "" as any,
-        date: new Date().toISOString().split("T")[0],
+        date: initialDate || new Date().toISOString().split("T")[0],
         category_id: 0,
         notes: "",
         type: "entrata",
@@ -49,8 +49,10 @@ export default function NewTransactionForm({ onSave, transaction, disabled, onCh
                 notes: transaction.notes || "",
                 type: transaction.type,
             });
+        } else if (initialDate) {
+            setFormData((prev) => ({ ...prev, date: initialDate }));
         }
-    }, [transaction]);
+    }, [transaction, initialDate]);
 
     // ----- Comunica dati aggiornati -----
     useEffect(() => {

--- a/Frontend-nextjs/app/(protected)/newTransaction/NewTransactionModal.tsx
+++ b/Frontend-nextjs/app/(protected)/newTransaction/NewTransactionModal.tsx
@@ -14,7 +14,7 @@ import { useCategories } from "@/context/contexts/CategoriesContext";
 // ============================
 // Componente principale
 // ============================
-export default function NewTransactionModal() {
+export default function NewTransactionModal({ defaultDate }: { defaultDate?: string }) {
     const { isOpen, closeModal, transactionToEdit, create, update } = useTransactions();
     const { categories } = useCategories();
     const [loading, setLoading] = useState(false);
@@ -100,6 +100,7 @@ export default function NewTransactionModal() {
                         disabled={loading}
                         onChangeForm={setFormValues}
                         onCancel={closeModal}
+                        initialDate={!transactionToEdit ? defaultDate : undefined}
                     />
                 </div>
             </div>

--- a/Frontend-nextjs/app/(protected)/panoramica/components/CalendarGrid.tsx
+++ b/Frontend-nextjs/app/(protected)/panoramica/components/CalendarGrid.tsx
@@ -44,7 +44,7 @@ const yearOptions = Array.from({ length: 15 }, (_, i) => currentYear - 7 + i);
 // ============================
 // CalendarGrid principale
 // ============================
-export default function CalendarGrid({ transactions }: CalendarGridProps) {
+export default function CalendarGrid({ transactions, onDayClick }: CalendarGridProps) {
     // Stato visualizzazione mese/anno
     const isLg = useMediaQuery("(min-width: 1024px)");
     const [viewYear, setViewYear] = useState(currentYear);
@@ -198,6 +198,7 @@ export default function CalendarGrid({ transactions }: CalendarGridProps) {
                                           week={week}
                                           transactions={weekTx}
                                           maxImporto={maxImportoGriglia}
+                                          onClickDay={onDayClick}
                                       />
                                   );
                               })
@@ -220,6 +221,7 @@ export default function CalendarGrid({ transactions }: CalendarGridProps) {
                                           transactions={dayTx}
                                           showWeekDay={false}
                                           maxImporto={maxImportoGriglia}
+                                          onClickDay={onDayClick}
                                       />
                                   );
                               })}

--- a/Frontend-nextjs/app/(protected)/panoramica/components/calendar/DayCell.tsx
+++ b/Frontend-nextjs/app/(protected)/panoramica/components/calendar/DayCell.tsx
@@ -66,11 +66,11 @@ export default function DayCell({ day, date, monthDelta, transactions, showWeekD
                 grid grid-cols-[1.1fr_1fr] gap-1 shadow-sm
                 ${opacity} ${border} ${todayClass}
                 transition-all duration-150
-                cursor-${txCount > 0 && onClickDay ? "pointer" : "default"}
+                cursor-${onClickDay ? "pointer" : "default"}
             `}
             title={tooltip}
             onClick={() => {
-                if (txCount > 0 && onClickDay) onClickDay(date, transactions);
+                if (onClickDay) onClickDay(date, transactions);
             }}
         >
             {/* ==== SINISTRA: Info giorno ==== */}

--- a/Frontend-nextjs/app/(protected)/panoramica/components/calendar/WeekRow.tsx
+++ b/Frontend-nextjs/app/(protected)/panoramica/components/calendar/WeekRow.tsx
@@ -7,7 +7,7 @@ import DayCell from "./DayCell";
 import { Transaction } from "@/types/models/transaction";
 import type { WeekRowProps } from "@/types";
 
-export default function WeekRow({ week, transactions, maxImporto }: WeekRowProps) {
+export default function WeekRow({ week, transactions, maxImporto, onClickDay }: WeekRowProps) {
     return (
         <>
             {/* Numero settimana */}
@@ -35,6 +35,7 @@ export default function WeekRow({ week, transactions, maxImporto }: WeekRowProps
                         transactions={dayTx}
                         showWeekDay={false}
                         maxImporto={maxImporto}
+                        onClickDay={onClickDay}
                     />
                 );
             })}

--- a/Frontend-nextjs/app/(protected)/panoramica/components/modal/DayTransactionsModal.tsx
+++ b/Frontend-nextjs/app/(protected)/panoramica/components/modal/DayTransactionsModal.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import Dialog from "@/app/components/ui/Dialog";
+import { PlusCircle, Pencil, Trash2 } from "lucide-react";
+import { Transaction } from "@/types/models/transaction";
+import { useTransactions } from "@/context/contexts/TransactionsContext";
+
+export type DayTransactionsModalProps = {
+    open: boolean;
+    onClose: () => void;
+    date: Date;
+    transactions: Transaction[];
+};
+
+export default function DayTransactionsModal({ open, onClose, date, transactions }: DayTransactionsModalProps) {
+    const { openModal, remove } = useTransactions();
+
+    const entrate = transactions.filter((t) => t.category?.type === "entrata");
+    const spese = transactions.filter((t) => t.category?.type === "spesa");
+    const somma = (arr: Transaction[]) => arr.reduce((tot, t) => tot + (typeof t.amount === "string" ? parseFloat(t.amount as any) : t.amount), 0);
+    const totalEntrate = somma(entrate);
+    const totalSpese = somma(spese);
+
+    const isoDate = date.toISOString().split("T")[0];
+    const label = date.toLocaleDateString("it-IT", {
+        weekday: "long",
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+    });
+
+    return (
+        <Dialog open={open} onClose={onClose}>
+            <div className="w-full max-w-md p-4 bg-bg rounded-2xl text-text border border-bg-elevate shadow-lg">
+                <h2 className="text-center text-lg font-bold mb-2 capitalize">{label}</h2>
+                <div className="flex justify-center gap-4 text-sm mb-4 font-medium">
+                    <span className="text-primary">+{totalEntrate.toFixed(2)}€</span>
+                    <span className="text-orange-400">-{totalSpese.toFixed(2)}€</span>
+                    <span className="font-semibold">{(totalEntrate - totalSpese).toFixed(2)}€</span>
+                </div>
+                <ul className="max-h-[50vh] overflow-y-auto space-y-2">
+                    {transactions.map((t) => (
+                        <li key={t.id} className="flex items-center justify-between gap-2 p-2 bg-bg-elevate rounded-xl border border-bg-soft">
+                            <div className="flex-1 min-w-0">
+                                <div className="font-semibold truncate">{t.description}</div>
+                                {t.category && <div className="text-xs text-text-secondary">{t.category.name}</div>}
+                            </div>
+                            <div className="flex items-center gap-2 flex-shrink-0">
+                                <span className={`text-sm font-semibold ${t.category?.type === "entrata" ? "text-primary" : "text-orange-500"}`}>{t.amount.toFixed(2)}€</span>
+                                <button
+                                    type="button"
+                                    onClick={() => {
+                                        onClose();
+                                        openModal(t);
+                                    }}
+                                    className="p-1 hover:text-primary"
+                                    title="Modifica"
+                                >
+                                    <Pencil size={16} />
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={() => remove(t.id)}
+                                    className="p-1 hover:text-danger"
+                                    title="Elimina"
+                                >
+                                    <Trash2 size={16} />
+                                </button>
+                            </div>
+                        </li>
+                    ))}
+                    {transactions.length === 0 && (
+                        <li className="text-center text-sm text-text-secondary py-6">Nessuna transazione</li>
+                    )}
+                </ul>
+                <div className="mt-4 flex justify-center">
+                    <button
+                        type="button"
+                        onClick={() => {
+                            onClose();
+                            openModal(null, isoDate);
+                        }}
+                        className="flex items-center gap-2 px-3 py-1.5 bg-primary-dark text-bg rounded-xl shadow hover:opacity-90 transition text-sm font-medium"
+                    >
+                        <PlusCircle size={16} /> Nuova transazione
+                    </button>
+                </div>
+            </div>
+        </Dialog>
+    );
+}

--- a/Frontend-nextjs/app/(protected)/panoramica/page.tsx
+++ b/Frontend-nextjs/app/(protected)/panoramica/page.tsx
@@ -4,14 +4,23 @@
 // Pagina riepilogo calendario — CRUD sincrono
 // ================================================
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useTransactions } from "@/context/contexts/TransactionsContext";
 import CalendarGrid from "./components/CalendarGrid";
 import CalendarGridSkeleton from "./components/skeleton/CalendarGridSkeleton";
 import NewTransactionButton from "../newTransaction/NewTransactionButton";
+import DayTransactionsModal from "./components/modal/DayTransactionsModal";
+import { Transaction } from "@/types";
 
 export default function PanoramicaPage() {
     const { transactions, loading, fetchAll } = useTransactions();
+    const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+    const [selectedTx, setSelectedTx] = useState<Transaction[]>([]);
+
+    const handleDayClick = (date: Date, tx: Transaction[]) => {
+        setSelectedDate(date);
+        setSelectedTx(tx);
+    };
 
     useEffect(() => {
         fetchAll();
@@ -65,7 +74,17 @@ export default function PanoramicaPage() {
                 </div>
             </div>
 
-            {loading ? <CalendarGridSkeleton /> : <CalendarGrid transactions={transactions} />}
+            {loading ? (
+                <CalendarGridSkeleton />
+            ) : (
+                <CalendarGrid transactions={transactions} onDayClick={handleDayClick} />
+            )}
+            <DayTransactionsModal
+                open={selectedDate !== null}
+                onClose={() => setSelectedDate(null)}
+                date={selectedDate || new Date()}
+                transactions={selectedTx}
+            />
         </div>
     );
 }

--- a/Frontend-nextjs/context/contexts/TransactionsContext.tsx
+++ b/Frontend-nextjs/context/contexts/TransactionsContext.tsx
@@ -32,8 +32,9 @@ type TransactionsContextType = {
     softMove: (original: Transaction, formData: Transaction, newType: "entrata" | "spesa") => Promise<void>;
     isOpen: boolean;
     transactionToEdit: Transaction | null;
-    openModal: (txToEdit?: Transaction | null) => void;
+    openModal: (txToEdit?: Transaction | null, defaultDate?: string) => void;
     closeModal: () => void;
+    defaultDate: string | null;
     monthBalance: number;
     yearBalance: number;
 };
@@ -54,6 +55,7 @@ export function TransactionsProvider({ children }: { children: React.ReactNode }
     // Modale
     const [isOpen, setIsOpen] = useState(false);
     const [transactionToEdit, setTransactionToEdit] = useState<Transaction | null>(null);
+    const [defaultDate, setDefaultDate] = useState<string | null>(null);
 
     // Per undo temporaneo
     const [lastDeleted, setLastDeleted] = useState<Transaction | null>(null);
@@ -209,12 +211,14 @@ export function TransactionsProvider({ children }: { children: React.ReactNode }
     // ==================================================
     // Gestione Modale
     // ==================================================
-    const openModal = (tx?: Transaction | null) => {
+    const openModal = (tx?: Transaction | null, date?: string) => {
         setTransactionToEdit(tx || null);
+        setDefaultDate(date ?? null);
         setIsOpen(true);
     };
     const closeModal = () => {
         setTransactionToEdit(null);
+        setDefaultDate(null);
         setIsOpen(false);
     };
 
@@ -234,6 +238,7 @@ export function TransactionsProvider({ children }: { children: React.ReactNode }
                 softMove,
                 isOpen,
                 transactionToEdit,
+                defaultDate,
                 openModal,
                 closeModal,
                 monthBalance,
@@ -241,7 +246,7 @@ export function TransactionsProvider({ children }: { children: React.ReactNode }
             }}
         >
             {children}
-            <NewTransactionModal />
+            <NewTransactionModal defaultDate={defaultDate ?? undefined} />
         </TransactionsContext.Provider>
     );
 }

--- a/Frontend-nextjs/types/newTransaction/index.ts
+++ b/Frontend-nextjs/types/newTransaction/index.ts
@@ -8,4 +8,5 @@ export type NewTransactionFormProps = {
     disabled?: boolean;
     onChangeForm?: (data: Partial<import("@/types").TransactionBase>) => void;
     onCancel?: () => void;
+    initialDate?: string;
 };

--- a/Frontend-nextjs/types/panoramica/components/calendar/index.ts
+++ b/Frontend-nextjs/types/panoramica/components/calendar/index.ts
@@ -15,6 +15,7 @@ export type WeekRowProps = {
     week: CalendarWeek;
     transactions: Transaction[];
     maxImporto: number;
+    onClickDay?: (date: Date, transactions: Transaction[]) => void;
 };
 
 export type YearDropdownProps = {

--- a/Frontend-nextjs/types/panoramica/components/index.ts
+++ b/Frontend-nextjs/types/panoramica/components/index.ts
@@ -2,6 +2,7 @@ import type { Transaction } from "@/types/models/transaction";
 
 export type CalendarGridProps = {
     transactions: Transaction[];
+    onDayClick?: (date: Date, transactions: Transaction[]) => void;
 };
 
 export * from "./calendar";


### PR DESCRIPTION
## Summary
- enhance logout button style to match profile button
- allow day cells to open details modal regardless of transactions
- enable CalendarGrid to emit day click events
- show transactions of the selected day via new `DayTransactionsModal`
- support pre-set date in transaction modal and context
- wire up modal to Panoramica page

## Testing
- `npm run build`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68876ee9b6648324b1ccf8fb86094367