### PR TITLE
Fix transaction category display and enforce API data

### DIFF
--- a/Backend/Modules/FinancialOverview/Services/FinancialOverviewService.php
+++ b/Backend/Modules/FinancialOverview/Services/FinancialOverviewService.php
@@ -41,7 +41,7 @@ class FinancialOverviewService
         $financialEntries = $entrate->concat($spese)->sortBy(function ($item) use ($sortBy) {
             return match ($sortBy) {
                 'type'     => class_basename($item),
-                'category' => $item->category->name ?? '',
+                'category' => $item->category?->name ?? '',
                 default    => $item->{$sortBy}
             };
         }, SORT_REGULAR, $sortDirection === 'desc');

--- a/Backend/Modules/FinancialOverview/tests/Feature/TransactionsCategoryTest.php
+++ b/Backend/Modules/FinancialOverview/tests/Feature/TransactionsCategoryTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Modules\FinancialOverview\Tests\Feature;
+
+use Modules\Categories\Models\Category;
+use Modules\Entrate\Models\Entrata;
+use Modules\Spese\Models\Spesa;
+use Tests\AuthenticatedTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class TransactionsCategoryTest extends AuthenticatedTestCase
+{
+    #[Test]
+    public function all_transactions_have_a_category_with_required_fields(): void
+    {
+        $incomeCat = Category::factory()->create([
+            'user_id' => $this->user->id,
+            'type'    => 'entrata',
+            'color'   => '#fff',
+            'icon'    => 'FaMoneyBillWave',
+        ]);
+
+        $expenseCat = Category::factory()->expense()->create([
+            'user_id' => $this->user->id,
+            'color'   => '#000',
+            'icon'    => 'FaCar',
+        ]);
+
+        Entrata::factory()->forUser($this->user)->forCategory($incomeCat)->create();
+        Spesa::factory()->forUser($this->user)->forCategory($expenseCat)->create();
+
+        $response = $this->getJson('/api/v1/financialoverview');
+        $response->assertStatus(200);
+
+        foreach ($response->json() as $entry) {
+            $this->assertNotEmpty($entry['category'], 'Missing category');
+            $this->assertArrayHasKey('id', $entry['category']);
+            $this->assertArrayHasKey('name', $entry['category']);
+            $this->assertArrayHasKey('type', $entry['category']);
+            $this->assertArrayHasKey('color', $entry['category']);
+            $this->assertArrayHasKey('icon', $entry['category']);
+        }
+    }
+}
+

--- a/Backend/phpunit.xml
+++ b/Backend/phpunit.xml
@@ -27,6 +27,10 @@
         <testsuite name="Module - Categories">
             <directory>Modules/Categories/tests</directory>
         </testsuite>
+
+        <testsuite name="Module - FinancialOverview">
+            <file>Modules/FinancialOverview/tests/Feature/TransactionsCategoryTest.php</file>
+        </testsuite>
         
     </testsuites>
 

--- a/Frontend-nextjs/app/(protected)/panoramica/components/modal/DayTransactionsModal.tsx
+++ b/Frontend-nextjs/app/(protected)/panoramica/components/modal/DayTransactionsModal.tsx
@@ -6,6 +6,7 @@ import { Transaction } from "@/types/models/transaction";
 import { useTransactions } from "@/context/contexts/TransactionsContext";
 import { Calendar, ArrowUpCircle, ArrowDownCircle, Calculator } from "lucide-react";
 import { CATEGORY_ICONS_MAP } from "@/utils/categoryOptions";
+import { FiTag } from "react-icons/fi";
 
 export type DayTransactionsModalProps = {
     open: boolean;
@@ -86,7 +87,6 @@ export default function DayTransactionsModal({ open, onClose, date, transactions
                             // Prendi icona e colore categoria (fallback icona generica)
                             const iconKey = t.category?.icon as keyof typeof CATEGORY_ICONS_MAP;
                             const IconComp = iconKey && CATEGORY_ICONS_MAP[iconKey];
-
                             const catColor = t.category?.color || "#ccc";
                             return (
                                 <li
@@ -98,17 +98,15 @@ export default function DayTransactionsModal({ open, onClose, date, transactions
                                         {IconComp ? (
                                             <IconComp size={22} color={catColor} className="drop-shadow" />
                                         ) : (
-                                            <span className="inline-block w-5 h-5 rounded-full bg-gray-200" />
+                                            <FiTag size={22} className="text-muted-foreground" />
                                         )}
                                     </div>
                                     {/* Descrizione + categoria */}
                                     <div className="flex-1 min-w-0">
                                         <div className="font-semibold truncate">{t.description}</div>
-                                        {t.category && (
-                                            <div className="text-xs text-text-secondary capitalize">
-                                                {t.category.name}
-                                            </div>
-                                        )}
+                                        <div className="text-xs text-text-secondary capitalize">
+                                            {t.category?.name || "Nessuna categoria"}
+                                        </div>
                                     </div>
                                     {/* Importo + azioni */}
                                     <div className="flex items-center gap-1 flex-shrink-0">

--- a/Frontend-nextjs/utils/categoryOptions.ts
+++ b/Frontend-nextjs/utils/categoryOptions.ts
@@ -25,11 +25,14 @@ import {
 import {
     FaUtensils,
     FaCar,
+    FaGamepad,
     FaRegSmile,
     FaHeartbeat,
     FaPlane,
     FaPiggyBank,
     FaRegMoneyBillAlt,
+    FaMoneyBillWave,
+    FaChartLine,
     FaBus,
     FaBolt,
     FaTree,
@@ -49,6 +52,7 @@ import {
     FaTshirt,
     FaDog,
     FaCat,
+    FaEllipsisH,
 } from "react-icons/fa";
 import {
     MdAttachMoney,
@@ -73,11 +77,14 @@ import {
     MdLocalHospital,
     MdSpa,
     MdBeachAccess,
+    MdOutlineLightbulb,
     MdOutlineSportsHandball,
     MdOutlineTrain,
     MdOutlineFlightTakeoff,
     MdOutlineShoppingCart,
 } from "react-icons/md";
+import { PiStudentBold } from "react-icons/pi";
+import { GiKnifeFork } from "react-icons/gi";
 
 // =======================
 // PALETTE COLORI ESTESA (MAXI, con nome)
@@ -193,14 +200,20 @@ export const CATEGORY_ICONS = [
     { value: "FiSun", name: "Sole" },
     { value: "FiMoon", name: "Luna" },
 
+    // Game Icons
+    { value: "GiKnifeFork", name: "Posate" },
+
     // FontAwesome (Fa)
     { value: "FaUtensils", name: "Cibo" },
     { value: "FaCar", name: "Auto" },
     { value: "FaRegSmile", name: "Sorriso" },
     { value: "FaHeartbeat", name: "Salute" },
     { value: "FaPlane", name: "Aereo" },
+    { value: "FaGamepad", name: "Gamepad" },
     { value: "FaPiggyBank", name: "Salvadanaio" },
     { value: "FaRegMoneyBillAlt", name: "Banconota" },
+    { value: "FaMoneyBillWave", name: "Busta paga" },
+    { value: "FaChartLine", name: "Investimenti" },
     { value: "FaBus", name: "Bus" },
     { value: "FaBolt", name: "Energia" },
     { value: "FaTree", name: "Albero" },
@@ -220,6 +233,7 @@ export const CATEGORY_ICONS = [
     { value: "FaTshirt", name: "Tshirt" },
     { value: "FaDog", name: "Cane" },
     { value: "FaCat", name: "Gatto" },
+    { value: "FaEllipsisH", name: "Altro" },
 
     // Material (Md)
     { value: "MdAttachMoney", name: "Soldi" },
@@ -244,6 +258,8 @@ export const CATEGORY_ICONS = [
     { value: "MdLocalHospital", name: "Ospedale" },
     { value: "MdSpa", name: "Spa" },
     { value: "MdBeachAccess", name: "Spiaggia" },
+    { value: "PiStudentBold", name: "Studente" },
+    { value: "MdOutlineLightbulb", name: "Lampadina" },
     { value: "MdOutlineSportsHandball", name: "Pallamano" },
     { value: "MdOutlineTrain", name: "Treno" },
     { value: "MdOutlineFlightTakeoff", name: "Decollo" },
@@ -273,13 +289,18 @@ export const CATEGORY_ICONS_MAP = {
     FiSun,
     FiMoon,
 
+    GiKnifeFork,
+
     FaUtensils,
     FaCar,
+    FaGamepad,
     FaRegSmile,
     FaHeartbeat,
     FaPlane,
     FaPiggyBank,
     FaRegMoneyBillAlt,
+    FaMoneyBillWave,
+    FaChartLine,
     FaBus,
     FaBolt,
     FaTree,
@@ -299,6 +320,7 @@ export const CATEGORY_ICONS_MAP = {
     FaTshirt,
     FaDog,
     FaCat,
+    FaEllipsisH,
 
     MdAttachMoney,
     MdHealthAndSafety,
@@ -322,10 +344,12 @@ export const CATEGORY_ICONS_MAP = {
     MdLocalHospital,
     MdSpa,
     MdBeachAccess,
+    MdOutlineLightbulb,
     MdOutlineSportsHandball,
     MdOutlineTrain,
     MdOutlineFlightTakeoff,
     MdOutlineShoppingCart,
+    PiStudentBold,
 } as const;
 
 export type CategoryIconName = keyof typeof CATEGORY_ICONS_MAP;


### PR DESCRIPTION
## Summary
- add missing icons and mapping for categories
- show generic icon and label if category is missing in day modal
- avoid null errors when sorting by category
- add backend test ensuring every transaction from API has a category

## Testing
- `composer dump-autoload`
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_688898389f2483249cea4b5945afc78a