### PR TITLE
Fix date for transaction modal and add expense/income buttons

### DIFF
--- a/Frontend-nextjs/app/(protected)/newTransaction/NewTransactionForm.tsx
+++ b/Frontend-nextjs/app/(protected)/newTransaction/NewTransactionForm.tsx
@@ -22,7 +22,15 @@ function cn(...classes: string[]) {
 // ╔═══════════════════════════════╗
 // ║      COMPONENTE PRINCIPALE    ║
 // ╚═══════════════════════════════╝
-export default function NewTransactionForm({ onSave, transaction, disabled, onChangeForm, onCancel, initialDate }: NewTransactionFormProps) {
+export default function NewTransactionForm({
+    onSave,
+    transaction,
+    disabled,
+    onChangeForm,
+    onCancel,
+    initialDate,
+    initialType,
+}: NewTransactionFormProps) {
     // ----- Stato form -----
     const [formData, setFormData] = useState<TransactionBase>({
         description: "",
@@ -30,7 +38,7 @@ export default function NewTransactionForm({ onSave, transaction, disabled, onCh
         date: initialDate || new Date().toISOString().split("T")[0],
         category_id: 0,
         notes: "",
-        type: "entrata",
+        type: initialType || "entrata",
     });
     const [errors, setErrors] = useState<Record<string, string>>({});
     const [loading, setLoading] = useState(false);
@@ -49,10 +57,14 @@ export default function NewTransactionForm({ onSave, transaction, disabled, onCh
                 notes: transaction.notes || "",
                 type: transaction.type,
             });
-        } else if (initialDate) {
-            setFormData((prev) => ({ ...prev, date: initialDate }));
+        } else {
+            setFormData((prev) => ({
+                ...prev,
+                ...(initialDate ? { date: initialDate } : {}),
+                ...(initialType ? { type: initialType } : {}),
+            }));
         }
-    }, [transaction, initialDate]);
+    }, [transaction, initialDate, initialType]);
 
     // ----- Comunica dati aggiornati -----
     useEffect(() => {

--- a/Frontend-nextjs/app/(protected)/newTransaction/NewTransactionModal.tsx
+++ b/Frontend-nextjs/app/(protected)/newTransaction/NewTransactionModal.tsx
@@ -14,7 +14,13 @@ import { useCategories } from "@/context/contexts/CategoriesContext";
 // ============================
 // Componente principale
 // ============================
-export default function NewTransactionModal({ defaultDate }: { defaultDate?: string }) {
+export default function NewTransactionModal({
+    defaultDate,
+    defaultType,
+}: {
+    defaultDate?: string;
+    defaultType?: "entrata" | "spesa";
+}) {
     const { isOpen, closeModal, transactionToEdit, create, update } = useTransactions();
     const { categories } = useCategories();
     const [loading, setLoading] = useState(false);
@@ -101,6 +107,7 @@ export default function NewTransactionModal({ defaultDate }: { defaultDate?: str
                         onChangeForm={setFormValues}
                         onCancel={closeModal}
                         initialDate={!transactionToEdit ? defaultDate : undefined}
+                        initialType={!transactionToEdit ? defaultType : undefined}
                     />
                 </div>
             </div>

--- a/Frontend-nextjs/app/(protected)/panoramica/components/modal/DayTransactionsModal.tsx
+++ b/Frontend-nextjs/app/(protected)/panoramica/components/modal/DayTransactionsModal.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import Dialog from "@/app/components/ui/Dialog";
-import { PlusCircle, Pencil, Trash2 } from "lucide-react";
+import { Pencil, Trash2, ArrowUpCircle, ArrowDownCircle, Calendar, Calculator } from "lucide-react";
 import { Transaction } from "@/types/models/transaction";
 import { useTransactions } from "@/context/contexts/TransactionsContext";
-import { Calendar, ArrowUpCircle, ArrowDownCircle, Calculator } from "lucide-react";
 import { CATEGORY_ICONS_MAP } from "@/utils/categoryOptions";
+import { toDateInputValue } from "@/utils/date";
 import { FiTag } from "react-icons/fi";
 
 export type DayTransactionsModalProps = {
@@ -26,7 +26,7 @@ export default function DayTransactionsModal({ open, onClose, date, transactions
     const totalEntrate = somma(entrate);
     const totalSpese = somma(spese);
 
-    const isoDate = date.toISOString().split("T")[0];
+    const isoDate = toDateInputValue(date);
     const label = date.toLocaleDateString("it-IT", {
         weekday: "long",
         year: "numeric",
@@ -149,16 +149,26 @@ export default function DayTransactionsModal({ open, onClose, date, transactions
                 </ul>
 
                 {/* ===== Azione: nuova transazione ===== */}
-                <div className="w-full flex justify-center border-t border-bg-elevate py-4">
+                <div className="w-full flex justify-center gap-3 border-t border-bg-elevate py-4">
                     <button
                         type="button"
                         onClick={() => {
                             onClose();
-                            openModal(null, isoDate);
+                            openModal(null, isoDate, "spesa");
                         }}
-                        className="flex items-center gap-2 px-4 py-2 bg-primary-dark text-bg rounded-xl shadow hover:opacity-90 transition text-base font-semibold active:scale-100"
+                        className="flex items-center gap-2 px-3 py-2 bg-orange-500 text-bg rounded-xl shadow hover:opacity-90 transition text-sm font-semibold active:scale-100"
                     >
-                        <PlusCircle size={18} /> Nuova transazione
+                        <ArrowDownCircle size={18} /> Aggiungi spesa
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => {
+                            onClose();
+                            openModal(null, isoDate, "entrata");
+                        }}
+                        className="flex items-center gap-2 px-3 py-2 bg-primary-dark text-bg rounded-xl shadow hover:opacity-90 transition text-sm font-semibold active:scale-100"
+                    >
+                        <ArrowUpCircle size={18} /> Aggiungi entrata
                     </button>
                 </div>
             </div>

--- a/Frontend-nextjs/context/contexts/TransactionsContext.tsx
+++ b/Frontend-nextjs/context/contexts/TransactionsContext.tsx
@@ -32,9 +32,14 @@ type TransactionsContextType = {
     softMove: (original: Transaction, formData: Transaction, newType: "entrata" | "spesa") => Promise<void>;
     isOpen: boolean;
     transactionToEdit: Transaction | null;
-    openModal: (txToEdit?: Transaction | null, defaultDate?: string) => void;
+    openModal: (
+        txToEdit?: Transaction | null,
+        defaultDate?: string,
+        defaultType?: "entrata" | "spesa"
+    ) => void;
     closeModal: () => void;
     defaultDate: string | null;
+    defaultType: "entrata" | "spesa" | null;
     monthBalance: number;
     yearBalance: number;
 };
@@ -56,6 +61,7 @@ export function TransactionsProvider({ children }: { children: React.ReactNode }
     const [isOpen, setIsOpen] = useState(false);
     const [transactionToEdit, setTransactionToEdit] = useState<Transaction | null>(null);
     const [defaultDate, setDefaultDate] = useState<string | null>(null);
+    const [defaultType, setDefaultType] = useState<"entrata" | "spesa" | null>(null);
 
     // Per undo temporaneo
     const [lastDeleted, setLastDeleted] = useState<Transaction | null>(null);
@@ -211,14 +217,20 @@ export function TransactionsProvider({ children }: { children: React.ReactNode }
     // ==================================================
     // Gestione Modale
     // ==================================================
-    const openModal = (tx?: Transaction | null, date?: string) => {
+    const openModal = (
+        tx?: Transaction | null,
+        date?: string,
+        type?: "entrata" | "spesa"
+    ) => {
         setTransactionToEdit(tx || null);
         setDefaultDate(date ?? null);
+        setDefaultType(type ?? null);
         setIsOpen(true);
     };
     const closeModal = () => {
         setTransactionToEdit(null);
         setDefaultDate(null);
+        setDefaultType(null);
         setIsOpen(false);
     };
 
@@ -239,6 +251,7 @@ export function TransactionsProvider({ children }: { children: React.ReactNode }
                 isOpen,
                 transactionToEdit,
                 defaultDate,
+                defaultType,
                 openModal,
                 closeModal,
                 monthBalance,
@@ -246,7 +259,10 @@ export function TransactionsProvider({ children }: { children: React.ReactNode }
             }}
         >
             {children}
-            <NewTransactionModal defaultDate={defaultDate ?? undefined} />
+            <NewTransactionModal
+                defaultDate={defaultDate ?? undefined}
+                defaultType={defaultType ?? undefined}
+            />
         </TransactionsContext.Provider>
     );
 }

--- a/Frontend-nextjs/types/newTransaction/index.ts
+++ b/Frontend-nextjs/types/newTransaction/index.ts
@@ -9,4 +9,5 @@ export type NewTransactionFormProps = {
     onChangeForm?: (data: Partial<import("@/types").TransactionBase>) => void;
     onCancel?: () => void;
     initialDate?: string;
+    initialType?: "entrata" | "spesa";
 };

--- a/Frontend-nextjs/utils/date.ts
+++ b/Frontend-nextjs/utils/date.ts
@@ -1,0 +1,4 @@
+export function toDateInputValue(date: Date): string {
+    const tz = date.getTimezoneOffset() * 60000;
+    return new Date(date.getTime() - tz).toISOString().split("T")[0];
+}


### PR DESCRIPTION
## Summary
- ensure day transactions modal uses correct local date
- allow passing default transaction type to NewTransactionModal
- add utility to format dates for HTML inputs
- introduce separate "Aggiungi spesa" and "Aggiungi entrata" buttons
- preselect transaction type when opening the create modal

## Testing
- `npm run build` in `Frontend-nextjs`
- `composer test` in `Backend`

------
https://chatgpt.com/codex/tasks/task_e_6888a0c9460883249c8e8e1218840796