### PR TITLE
Improve legal info and transaction UX

### DIFF
--- a/Backend/Modules/User/Database/Seeders/UserDBSeeder.php
+++ b/Backend/Modules/User/Database/Seeders/UserDBSeeder.php
@@ -39,14 +39,15 @@ class UserDBSeeder extends Seeder
                 'email_verified_at' => now(),
                 'remember_token'    => Str::random(10),
                 'is_admin'          => true,
+                'has_accepted_terms'=> true,
             ]
         );
 
         // =========================================================================
         // 🧪 Generazione utenti fittizi
         // =========================================================================
-        $this->logInfo('User', 'Generazione 3 utenti fittizi...', '🧪');
-        User::factory(3)->create();
+        $this->logInfo('User', 'Generazione 1 utente demo...', '🧪');
+        User::factory()->create(['has_accepted_terms' => true]);
 
         // =========================================================================
         // ✅ Fine seeding

--- a/Frontend-nextjs/app/(auth)/login/form/modal/RegisterModal.tsx
+++ b/Frontend-nextjs/app/(auth)/login/form/modal/RegisterModal.tsx
@@ -8,6 +8,8 @@ import { Button } from "@/app/components/ui/Button";
 import PasswordInput from "../form-components/PasswordInput";
 import { handleRegister } from "@/lib/auth/handleRegister";
 import { PASSWORD_RULES_TEXT, isPasswordValid } from "@/lib/auth/passwordRules";
+import PrivacyModal from "@/app/components/legal/PrivacyModal";
+import TermsModal from "@/app/components/legal/TermsModal";
 
 interface Props {
     isOpen: boolean;
@@ -27,6 +29,8 @@ export default function RegisterModal({ isOpen, onClose }: Props) {
     const [loading, setLoading] = useState(false);
     const [message, setMessage] = useState<string | null>(null);
     const [error, setError] = useState<string | null>(null);
+    const [showPrivacy, setShowPrivacy] = useState(false);
+    const [showTerms, setShowTerms] = useState(false);
     const passwordValid = isPasswordValid(form.password);
 
     const handleChange = (field: string, value: any) => {
@@ -127,8 +131,22 @@ export default function RegisterModal({ isOpen, onClose }: Props) {
                             required
                         />
                         <span>
-                            Accetto <a href="/privacy" className="underline">Privacy</a> e
-                            <a href="/termini" className="underline ml-1">Termini</a>
+                            Accetto
+                            <button
+                                type="button"
+                                onClick={() => setShowPrivacy(true)}
+                                className="underline ml-1"
+                            >
+                                Privacy
+                            </button>
+                            e
+                            <button
+                                type="button"
+                                onClick={() => setShowTerms(true)}
+                                className="underline ml-1"
+                            >
+                                Termini
+                            </button>
                         </span>
                     </label>
                     {error && <p className="text-danger text-sm">{error}</p>}
@@ -138,6 +156,8 @@ export default function RegisterModal({ isOpen, onClose }: Props) {
                     </Button>
                 </form>
             </ModalLayout>
+            <PrivacyModal open={showPrivacy} onClose={() => setShowPrivacy(false)} />
+            <TermsModal open={showTerms} onClose={() => setShowTerms(false)} />
         </Dialog>
     );
 }

--- a/Frontend-nextjs/app/(protected)/layout-components/Header.tsx
+++ b/Frontend-nextjs/app/(protected)/layout-components/Header.tsx
@@ -6,7 +6,10 @@
 
 import { signOut } from "next-auth/react";
 import { LogOut, UserCircle } from "lucide-react";
+import { useState } from "react";
 import BetaBadge from "@/app/components/BetaBadge";
+import PrivacyModal from "@/app/components/legal/PrivacyModal";
+import TermsModal from "@/app/components/legal/TermsModal";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
@@ -19,6 +22,8 @@ export default function Header() {
     // ─────────── USER & ROUTER ───────────
     const { user } = useUser();
     const router = useRouter();
+    const [showPrivacy, setShowPrivacy] = useState(false);
+    const [showTerms, setShowTerms] = useState(false);
 
     // ─────────── USERNAME ───────────
     const username = user?.username;
@@ -78,6 +83,19 @@ export default function Header() {
                 )}
 
                 <button
+                    onClick={() => setShowPrivacy(true)}
+                    className="text-xs underline text-gray-300 hover:text-white"
+                >
+                    Privacy
+                </button>
+                <button
+                    onClick={() => setShowTerms(true)}
+                    className="text-xs underline text-gray-300 hover:text-white"
+                >
+                    Termini
+                </button>
+
+                <button
                     onClick={handleLogout}
                     className="flex items-center gap-1 px-3 py-1 rounded-full bg-white/10 text-white hover:text-red-400 ring-1 ring-white/20 hover:ring-red-400 transition shadow-sm focus:outline-none focus:ring-2 focus:ring-red-400"
                 >
@@ -85,6 +103,8 @@ export default function Header() {
                     <LogOut size={16} />
                 </button>
             </div>
+            <PrivacyModal open={showPrivacy} onClose={() => setShowPrivacy(false)} />
+            <TermsModal open={showTerms} onClose={() => setShowTerms(false)} />
         </header>
     );
 }

--- a/Frontend-nextjs/app/(protected)/layout-components/Sidebar.tsx
+++ b/Frontend-nextjs/app/(protected)/layout-components/Sidebar.tsx
@@ -23,6 +23,9 @@ import {
 import { useSidebar } from "@/context/contexts/SidebarContext";
 import { useThemeContext } from "@/context/contexts/ThemeContext";
 import { useState } from "react";
+import BetaBadge from "@/app/components/BetaBadge";
+import PrivacyModal from "@/app/components/legal/PrivacyModal";
+import TermsModal from "@/app/components/legal/TermsModal";
 import { themeMeta } from "@/lib/themeUtils";
 
 // ────────────────────────────────
@@ -49,6 +52,8 @@ export default function Sidebar() {
     // ========== Stato sidebar ==========
     const { isCollapsed, toggleSidebar } = useSidebar();
     const [isOpenMobile, setIsOpenMobile] = useState(false);
+    const [showPrivacy, setShowPrivacy] = useState(false);
+    const [showTerms, setShowTerms] = useState(false);
     const pathname = usePathname();
 
     // ========== Gestione temi ==========
@@ -97,6 +102,7 @@ export default function Sidebar() {
                     onClick={() => setIsOpenMobile(false)}
                 >
                     <span className="ml-2 text-xl font-bold text-primary">Synapsi</span>
+                    <BetaBadge inline className="ml-1" />
                 </Link>
 
                 {/* ----------- Navigazione ----------- */}
@@ -143,6 +149,16 @@ export default function Sidebar() {
                         );
                     })}
                 </div>
+                <div className="p-4 border-t border-white/10 text-center text-xs space-x-2">
+                    <button className="underline hover:text-white" onClick={() => setShowPrivacy(true)}>
+                        Privacy
+                    </button>
+                    <button className="underline hover:text-white" onClick={() => setShowTerms(true)}>
+                        Termini
+                    </button>
+                </div>
+                <PrivacyModal open={showPrivacy} onClose={() => setShowPrivacy(false)} />
+                <TermsModal open={showTerms} onClose={() => setShowTerms(false)} />
             </aside>
         </>
     );

--- a/Frontend-nextjs/app/(protected)/transazioni/components/TransactionsList.tsx
+++ b/Frontend-nextjs/app/(protected)/transazioni/components/TransactionsList.tsx
@@ -3,7 +3,7 @@
 // Lista transazioni con filtro e tabella — uniformata
 // ====================================================
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import TransactionListFilter from "./list/TransactionListFilter";
 import TransactionTable from "./list/TransactionTable";
 import { useSelection } from "@/context/contexts/SelectionContext";
@@ -24,6 +24,7 @@ export default function TransactionsList({ transactions, onSelect, selectedId }:
 
     const { categories } = useCategories();
     const { isSelectionMode, selectedIds, setSelectedIds } = useSelection();
+    const [visible, setVisible] = useState(20);
 
     // ===== Filtro transazioni =====
     const filtered = useMemo(() => {
@@ -34,6 +35,10 @@ export default function TransactionsList({ transactions, onSelect, selectedId }:
             return matchType && matchCategory && matchSearch;
         });
     }, [transactions, filter]);
+
+    useEffect(() => {
+        setVisible(20);
+    }, [filter, transactions]);
 
     // ===== Render Vuoto =====
     if (!transactions.length) {
@@ -64,13 +69,27 @@ export default function TransactionsList({ transactions, onSelect, selectedId }:
             {/* ====== Tabella ====== */}
             <div className="flex-1 min-w-0">
                 <TransactionTable
-                    data={filtered}
+                    data={filtered.slice(0, visible)}
                     onRowClick={onSelect}
                     selectedId={selectedId}
                     isSelectionMode={isSelectionMode}
                     selectedIds={selectedIds}
                     setSelectedIds={setSelectedIds}
                 />
+                {visible < filtered.length ? (
+                    <div className="text-center mt-4">
+                        <button
+                            onClick={() => setVisible((v) => v + 20)}
+                            className="px-3 py-1 rounded bg-primary text-white text-sm"
+                        >
+                            Carica altre transazioni
+                        </button>
+                    </div>
+                ) : (
+                    <div className="text-center text-sm text-muted-foreground mt-4">
+                        Hai visualizzato tutte le transazioni.
+                    </div>
+                )
             </div>
         </div>
     );

--- a/Frontend-nextjs/app/components/BetaBadge.tsx
+++ b/Frontend-nextjs/app/components/BetaBadge.tsx
@@ -2,20 +2,20 @@
 
 interface Props {
     inline?: boolean;
+    floating?: boolean;
+    className?: string;
 }
 
-export default function BetaBadge({ inline = false }: Props) {
+export default function BetaBadge({ inline = false, floating = false, className = "" }: Props) {
     if (process.env.NEXT_PUBLIC_BETA !== "true") return null;
     const text =
-        "Versione Beta - Alcuni dati potrebbero essere cancellati. " +
-        "Alcune funzionalita potrebbero essere modificate o rimosse. " +
-        "Feedback e bug possono essere comunicati a support@synapsy.app";
-    const className = inline
-        ? "ml-2 px-2 py-0.5 text-xs font-bold rounded bg-yellow-300 text-black"
-        :
-          "fixed top-2 right-2 z-50 px-2 py-0.5 text-xs font-bold rounded bg-yellow-300 text-black";
+        "Versione Beta: alcuni dati potrebbero essere cancellati; " +
+        "funzionalità e UI potrebbero cambiare senza preavviso; " +
+        "non usare per dati sensibili reali; per feedback scrivi a support@synapsy.app.";
+    const base = "px-2 py-0.5 text-xs font-bold rounded bg-yellow-300 text-black";
+    const pos = floating ? "fixed top-2 right-2 z-50" : inline ? "ml-2" : "";
     return (
-        <span className={className} title={text}>
+        <span className={`${base} ${pos} ${className}`.trim()} title={text}>
             Beta
         </span>
     );

--- a/Frontend-nextjs/app/components/legal/PrivacyContent.tsx
+++ b/Frontend-nextjs/app/components/legal/PrivacyContent.tsx
@@ -1,0 +1,22 @@
+export default function PrivacyContent() {
+  return (
+    <div className="prose prose-sm max-w-none space-y-3">
+      <p>
+        Questa versione beta registra i dati forniti in fase di registrazione
+        (nome, email, username e password). I dati sono utilizzati
+        esclusivamente per testare Synapsy e potrebbero essere cancellati senza
+        preavviso.
+      </p>
+      <p>
+        Non condividiamo le informazioni con terze parti. Puoi richiederne la
+        cancellazione in qualsiasi momento scrivendo a
+        <a href="mailto:support@synapsy.app">support@synapsy.app</a>.
+      </p>
+      <p>
+        Utilizzando la beta accetti che eventuali errori possano causare perdita
+        di dati. Segnalaci bug o suggerimenti a
+        <a href="mailto:support@synapsy.app">support@synapsy.app</a>.
+      </p>
+    </div>
+  );
+}

--- a/Frontend-nextjs/app/components/legal/PrivacyModal.tsx
+++ b/Frontend-nextjs/app/components/legal/PrivacyModal.tsx
@@ -1,0 +1,19 @@
+"use client";
+import Dialog from "@/app/components/ui/Dialog";
+import ModalLayout from "@/app/components/ui/ModalLayout";
+import PrivacyContent from "./PrivacyContent";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function PrivacyModal({ open, onClose }: Props) {
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <ModalLayout title="Informativa Privacy" onClose={onClose}>
+        <PrivacyContent />
+      </ModalLayout>
+    </Dialog>
+  );
+}

--- a/Frontend-nextjs/app/components/legal/TermsContent.tsx
+++ b/Frontend-nextjs/app/components/legal/TermsContent.tsx
@@ -1,0 +1,21 @@
+export default function TermsContent() {
+  return (
+    <div className="prose prose-sm max-w-none space-y-3">
+      <p>
+        L'accesso a Synapsy avviene in versione beta e viene fornito "così com'è"
+        senza garanzie. Funzionalità e interfaccia possono variare senza
+        preavviso e le informazioni salvate potrebbero essere rimosse durante il
+        periodo di test.
+      </p>
+      <p>
+        Non utilizzare il servizio per dati sensibili o senza copia di backup.
+        L'autore non è responsabile per malfunzionamenti o perdite di dati.
+      </p>
+      <p>
+        Gli account e i relativi dati potranno essere cancellati in qualsiasi
+        momento. Per problemi o feedback scrivi a
+        <a href="mailto:support@synapsy.app">support@synapsy.app</a>.
+      </p>
+    </div>
+  );
+}

--- a/Frontend-nextjs/app/components/legal/TermsModal.tsx
+++ b/Frontend-nextjs/app/components/legal/TermsModal.tsx
@@ -1,0 +1,19 @@
+"use client";
+import Dialog from "@/app/components/ui/Dialog";
+import ModalLayout from "@/app/components/ui/ModalLayout";
+import TermsContent from "./TermsContent";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function TermsModal({ open, onClose }: Props) {
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <ModalLayout title="Termini di servizio" onClose={onClose}>
+        <TermsContent />
+      </ModalLayout>
+    </Dialog>
+  );
+}

--- a/Frontend-nextjs/app/layout.tsx
+++ b/Frontend-nextjs/app/layout.tsx
@@ -2,7 +2,6 @@
 import "@/styles/globals.css";
 import GlobalContextProvider from "@/context/GlobalContextProvider";
 import { Toaster } from "sonner";
-import BetaBadge from "@/app/components/BetaBadge";
 
 export const metadata = {
     title: "Synapsy",
@@ -13,7 +12,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     return (
         <html lang="it" className="dark" data-theme="dark" suppressHydrationWarning>
             <body>
-                <BetaBadge />
                 {/* Toaster e contesti globali */}
                 {/* ==================================== */}
                 {/*      TOASTER CENTRATO & STILOSO      */}

--- a/Frontend-nextjs/app/privacy/page.tsx
+++ b/Frontend-nextjs/app/privacy/page.tsx
@@ -1,8 +1,9 @@
+import PrivacyContent from "@/app/components/legal/PrivacyContent";
+
 export default function PrivacyPage() {
-    return (
-        <div className="p-8 prose mx-auto">
-            <h1>Privacy</h1>
-            <p>Informativa sulla privacy della versione beta di Synapsy.</p>
-        </div>
-    );
+  return (
+    <div className="p-8 mx-auto max-w-2xl">
+      <PrivacyContent />
+    </div>
+  );
 }

--- a/Frontend-nextjs/app/termini/page.tsx
+++ b/Frontend-nextjs/app/termini/page.tsx
@@ -1,8 +1,9 @@
+import TermsContent from "@/app/components/legal/TermsContent";
+
 export default function TerminiPage() {
-    return (
-        <div className="p-8 prose mx-auto">
-            <h1>Termini di servizio</h1>
-            <p>Condizioni di utilizzo della versione beta di Synapsy.</p>
-        </div>
-    );
+  return (
+    <div className="p-8 mx-auto max-w-2xl">
+      <TermsContent />
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add privacy & terms content with reusable modals
- update registration flow to show legal modals
- adjust sidebar and header to link legal modals
- optimize BetaBadge component and positioning
- load transactions progressively with "load more"
- update user seeder for single demo user and accepted terms

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6889fb9a2484832485cc703a31ae0f66