### PR TITLE
Fix username uniqueness handling

### DIFF
--- a/Backend/Modules/User/Database/Migrations/0001_01_01_000000_create_users_table.php
+++ b/Backend/Modules/User/Database/Migrations/0001_01_01_000000_create_users_table.php
@@ -24,7 +24,8 @@ return new class extends Migration
             // -------------------------
             $table->string('name'); // Nome
             $table->string('surname')->nullable(); // Cognome (opzionale)
-            $table->string('username', 64)->unique()->nullable(); // Username univoco (opzionale)
+            // Username univoco e obbligatorio
+            $table->string('username', 64)->unique();
             $table->string('email', 191)->unique(); // Email univoca
 
             // -------------------------

--- a/Backend/Modules/User/Http/Controllers/Auth/RegisteredUserController.php
+++ b/Backend/Modules/User/Http/Controllers/Auth/RegisteredUserController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rules;
+use Illuminate\Validation\Rule;
 use Illuminate\View\View;
 
 class RegisteredUserController extends Controller
@@ -31,14 +32,22 @@ class RegisteredUserController extends Controller
     {
         $request->validate([
             'name' => ['required', 'string', 'max:255'],
+            'surname' => ['nullable', 'string', 'max:255'],
             'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:'.User::class],
+            'username' => ['required', 'string', 'max:64', 'unique:'.User::class],
+            'has_accepted_terms' => ['accepted'],
+            'theme' => ['nullable', 'string', Rule::in(['system','light','dark','emerald','solarized'])],
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
         ]);
 
         $user = User::create([
             'name' => $request->name,
+            'surname' => $request->surname,
             'email' => $request->email,
+            'username' => $request->username,
             'password' => Hash::make($request->password),
+            'theme' => $request->theme,
+            'has_accepted_terms' => $request->has_accepted_terms,
         ]);
 
         event(new Registered($user));

--- a/Backend/tests/Feature/Auth/RegistrationTest.php
+++ b/Backend/tests/Feature/Auth/RegistrationTest.php
@@ -31,7 +31,9 @@ class RegistrationTest extends TestCase
             ->post('/register', [
                 '_token'                 => 'test_csrf_token',
                 'name'                   => 'Test User',
+                'username'               => 'testuser',
                 'email'                  => 'test@example.com',
+                'has_accepted_terms'     => '1',
                 'password'               => 'password',
                 'password_confirmation'  => 'password',
             ]);


### PR DESCRIPTION
## Summary
- make `users.username` required in migration
- update registration controller to handle new fields
- adjust registration test to include username and terms

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688a3eb4f0c883249e29e1e0277b174a