### PR TITLE
fix: Unifica utilities data, correggi RicorrentiCard e pulizia duplicati

### DIFF
--- a/Frontend-nextjs/app/(protected)/home/cards/RicorrentiCard.tsx
+++ b/Frontend-nextjs/app/(protected)/home/cards/RicorrentiCard.tsx
@@ -4,37 +4,7 @@ import DashboardCard from "./DashboardCard";
 import { useRicorrenze } from "@/context/contexts/RicorrenzeContext";
 import LoadingSpinnerCard from "./loading/LoadingSpinnerCard";
 import { useRenderTimer } from "@/app/(protected)/home/utils/useRenderTimer";
-
-// ===============================
-// Utility
-// ===============================
-function isThisWeek(dateStr: string) {
-    const now = new Date();
-    const start = new Date(now);
-    start.setDate(now.getDate() - now.getDay());
-    const end = new Date(start);
-    end.setDate(start.getDate() + 7);
-    const date = new Date(dateStr);
-    return date >= start && date < end;
-}
-function isThisMonth(dateStr: string) {
-    const now = new Date();
-    const date = new Date(dateStr);
-    return date.getMonth() === now.getMonth() && date.getFullYear() === now.getFullYear();
-}
-function isThisYear(dateStr: string) {
-    const now = new Date();
-    const date = new Date(dateStr);
-    return date.getFullYear() === now.getFullYear();
-}
-function formatDataIt(dateStr: string) {
-    const date = new Date(dateStr);
-    return date.toLocaleDateString("it-IT", {
-        day: "2-digit",
-        month: "long",
-        year: "numeric",
-    });
-}
+import { formatDataIt, isThisWeek, isThisMonth, isThisYear } from "@/utils/date";
 
 // ===============================
 // Componente principale
@@ -52,6 +22,7 @@ export default function RicorrentiCard() {
         const mese = attive.filter((r) => isThisMonth(r.prossima)).length;
         const anno = attive.filter((r) => isThisYear(r.prossima)).length;
         // Ricorrenza con prossima più vecchia
+        // Basata su "prossima" in assenza della data di creazione effettiva
         const piuVecchia = attive.length
             ? [...attive].sort((a, b) => new Date(a.prossima).getTime() - new Date(b.prossima).getTime())[0]
             : null;

--- a/Frontend-nextjs/app/(protected)/home/cards/TransazioniCard.tsx
+++ b/Frontend-nextjs/app/(protected)/home/cards/TransazioniCard.tsx
@@ -9,50 +9,14 @@ import { fetchTransactions } from "@/lib/api/transactionsApi";
 import { Transaction } from "@/types/models/transaction";
 import { useSession } from "next-auth/react";
 import LoadingSpinnerCard from "./loading/LoadingSpinnerCard";
-import { useRenderTimer } from "@/app/(protected)/home/utils/useRenderTimer"; // Debug per vedere quanto tempo ci mette a rtenderizzare
-
-// ======================================================================
-// Utility: Formatta la data in italiano leggibile (es: 23 luglio 2024)
-// ======================================================================
-function formatDataIt(dateStr: string) {
-    const date = new Date(dateStr);
-    return date.toLocaleDateString("it-IT", {
-        day: "2-digit",
-        month: "long",
-        year: "numeric",
-    });
-}
-
-// ======================================================================
-// Utility date per settimana, mese e anno
-// ======================================================================
-function isThisWeek(dateStr: string) {
-    const now = new Date();
-    const start = new Date(now);
-    start.setDate(now.getDate() - now.getDay());
-    const end = new Date(start);
-    end.setDate(start.getDate() + 7);
-    const date = new Date(dateStr);
-    return date >= start && date < end;
-}
-
-function isThisMonth(dateStr: string) {
-    const now = new Date();
-    const date = new Date(dateStr);
-    return date.getMonth() === now.getMonth() && date.getFullYear() === now.getFullYear();
-}
-
-function isThisYear(dateStr: string) {
-    const now = new Date();
-    const date = new Date(dateStr);
-    return date.getFullYear() === now.getFullYear();
-}
+import { useRenderTimer } from "@/app/(protected)/home/utils/useRenderTimer"; // Debug per vedere quanto tempo ci mette a renderizzare
+import { formatDataIt, isThisWeek, isThisMonth, isThisYear } from "@/utils/date";
 
 // ======================================================================
 // Componente principale
 // ======================================================================
 export default function TransazioniCard() {
-    useRenderTimer("TransazioniCard"); // Debug per vedere quanto tempo ci mette a rtenderizzare
+    useRenderTimer("TransazioniCard"); // Debug per vedere quanto tempo ci mette a renderizzare
     const { data: session } = useSession();
     const token = session?.accessToken;
 

--- a/Frontend-nextjs/utils/date.ts
+++ b/Frontend-nextjs/utils/date.ts
@@ -1,5 +1,44 @@
+// ============================================
+// Utility per formattazione data in italiano
+// ============================================
+export function formatDataIt(dateStr: string): string {
+    const date = new Date(dateStr);
+    return date.toLocaleDateString("it-IT", {
+        day: "2-digit",
+        month: "long",
+        year: "numeric",
+    });
+}
+
+// ============================================
+// Utility per verifiche periodo corrente
+// ============================================
+export function isThisWeek(dateStr: string): boolean {
+    const now = new Date();
+    const start = new Date(now);
+    start.setDate(now.getDate() - now.getDay());
+    const end = new Date(start);
+    end.setDate(start.getDate() + 7);
+    const date = new Date(dateStr);
+    return date >= start && date < end;
+}
+
+export function isThisMonth(dateStr: string): boolean {
+    const now = new Date();
+    const date = new Date(dateStr);
+    return date.getMonth() === now.getMonth() && date.getFullYear() === now.getFullYear();
+}
+
+export function isThisYear(dateStr: string): boolean {
+    const now = new Date();
+    const date = new Date(dateStr);
+    return date.getFullYear() === now.getFullYear();
+}
+
+// ============================================
+// Utility per input di tipo "date"
+// ============================================
 export function toDateInputValue(date: Date): string {
     const tz = date.getTimezoneOffset() * 60000;
     return new Date(date.getTime() - tz).toISOString().split("T")[0];
 }
-


### PR DESCRIPTION
## Summary
- centralize italian date helpers and period check utilities
- reuse shared date helpers in TransazioniCard and RicorrentiCard
- show oldest active recurrence with divider and clarified comment

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68908d31fcf08324a0e8e0b4d332fd05