### PR TITLE
feat: add avatar url helper

### DIFF
--- a/Frontend-nextjs/app/(protected)/layout-components/Header.tsx
+++ b/Frontend-nextjs/app/(protected)/layout-components/Header.tsx
@@ -11,6 +11,7 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
 import { useUser } from "@/context/contexts/UserContext";
+import getAvatarUrl from "@/utils/getAvatarUrl";
 
 // ==================================================
 // Header principale
@@ -22,12 +23,7 @@ export default function Header() {
 
     // ─────────── USERNAME ───────────
     const username = user?.username;
-    const avatarUrl = user?.avatar
-        ? `${(process.env.NEXT_PUBLIC_CDN_URL || "/images/avatars").replace(/\/$/, "")}/${user.avatar.replace(
-              /^\//,
-              ""
-          )}`
-        : undefined;
+    const avatarUrl = user?.avatar ? getAvatarUrl(user.avatar) : undefined;
 
     // ─────────── LOGOUT HANDLER ───────────
     const handleLogout = async () => {

--- a/Frontend-nextjs/app/(protected)/profilo/ProfilePage.tsx
+++ b/Frontend-nextjs/app/(protected)/profilo/ProfilePage.tsx
@@ -16,6 +16,7 @@ import PendingEmailNotice from "@/app/components/PendingEmailNotice";
 import { UserRound } from "lucide-react";
 import LegalLinks from "@/app/components/legal/LegalLinks";
 import DeleteAccountSection from "./components/DeleteAccountSection";
+import getAvatarUrl from "@/utils/getAvatarUrl";
 
 // ======================================================
 // Componente principale
@@ -52,8 +53,7 @@ export default function ProfilePage() {
         setShowPicker(false);
     };
 
-    const cdn = process.env.NEXT_PUBLIC_CDN_URL || "/images/avatars";
-    const avatarUrl = `${cdn.replace(/\/$/, "")}/${form.avatar.replace(/^\//, "")}`;
+    const avatarUrl = getAvatarUrl(form.avatar);
 
     // -----------------------------------
     // Render pagina

--- a/Frontend-nextjs/app/components/AvatarCard.tsx
+++ b/Frontend-nextjs/app/components/AvatarCard.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import clsx from "clsx";
+import getAvatarUrl from "@/utils/getAvatarUrl";
 
 export type AvatarCardProps = {
     src: string;
@@ -11,8 +12,7 @@ export type AvatarCardProps = {
 };
 
 export default function AvatarCard({ src, label, selected, onClick }: AvatarCardProps) {
-    const cdn = process.env.NEXT_PUBLIC_CDN_URL || "/images/avatars";
-    const url = `${cdn.replace(/\/$/, "")}/${src.replace(/^\//, "")}`;
+    const url = getAvatarUrl(src);
 
     return (
         <div className="flex flex-col items-center gap-2">

--- a/Frontend-nextjs/utils/getAvatarUrl.ts
+++ b/Frontend-nextjs/utils/getAvatarUrl.ts
@@ -1,0 +1,16 @@
+export function getAvatarUrl(path: string): string {
+    const cdn = process.env.NEXT_PUBLIC_CDN_URL;
+    const normalizedPath = path.replace(/^\/+/, "");
+
+    if (cdn) {
+        return `${cdn.replace(/\/+$/, "")}/${normalizedPath}`;
+    }
+
+    const localBase = "/images/avatars";
+    if (normalizedPath.startsWith("images/avatars")) {
+        return `/${normalizedPath}`;
+    }
+    return `${localBase}/${normalizedPath}`;
+}
+
+export default getAvatarUrl;


### PR DESCRIPTION
## Summary
- add reusable `getAvatarUrl` helper for avatars
- refactor components to use helper

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68932976b1fc83248ba79ccb1ad16bd0