### PR TITLE
feat(profile): enable cancel edits on profile rows

### DIFF
--- a/Frontend-nextjs/app/(protected)/profilo/ProfilePage.tsx
+++ b/Frontend-nextjs/app/(protected)/profilo/ProfilePage.tsx
@@ -27,18 +27,34 @@ export default function ProfilePage() {
 
     const [form, setForm] = useState<UserType>(DEFAULT_USER);
     const [editing, setEditing] = useState<{ [K in keyof UserType]?: boolean }>({});
+    const [backup, setBackup] = useState<Partial<UserType>>({});
     const [showPicker, setShowPicker] = useState(false);
 
     useEffect(() => {
         if (user) setForm(user);
     }, [user]);
 
-    const handleEdit = (field: keyof UserType) => setEditing({ ...editing, [field]: true });
+    const handleEdit = (field: keyof UserType) => {
+        setBackup((b) => ({ ...b, [field]: form[field] }));
+        setEditing({ ...editing, [field]: true });
+    };
     const handleChange = (field: keyof UserType, value: string) => setForm({ ...form, [field]: value });
     const handleSave = async (field: keyof UserType) => {
         if (field === "theme") setTheme(form.theme, false);
         await update({ [field]: form[field] } as Partial<UserType>);
         setEditing({ ...editing, [field]: false });
+        setBackup((b) => {
+            const { [field]: _omit, ...rest } = b;
+            return rest;
+        });
+    };
+    const handleCancel = (field: keyof UserType) => {
+        setForm((f) => ({ ...f, [field]: backup[field] as any }));
+        setEditing({ ...editing, [field]: false });
+        setBackup((b) => {
+            const { [field]: _omit, ...rest } = b;
+            return rest;
+        });
     };
     const handleAvatarChange = async (val: string) => {
         await update({ avatar: val });
@@ -112,6 +128,7 @@ export default function ProfilePage() {
                             onEdit={() => handleEdit("name")}
                             onChange={(v) => handleChange("name", v)}
                             onSave={() => handleSave("name")}
+                            onCancel={() => handleCancel("name")}
                         />
                         <ProfileRow
                             label="Cognome"
@@ -120,6 +137,7 @@ export default function ProfilePage() {
                             onEdit={() => handleEdit("surname")}
                             onChange={(v) => handleChange("surname", v)}
                             onSave={() => handleSave("surname")}
+                            onCancel={() => handleCancel("surname")}
                         />
                         <ProfileRow
                             label="Username"
@@ -128,6 +146,7 @@ export default function ProfilePage() {
                             onEdit={() => handleEdit("username")}
                             onChange={(v) => handleChange("username", v)}
                             onSave={() => handleSave("username")}
+                            onCancel={() => handleCancel("username")}
                         />
                         <ProfileRow
                             label="Email"
@@ -136,6 +155,7 @@ export default function ProfilePage() {
                             onEdit={() => handleEdit("email")}
                             onChange={(v) => handleChange("email", v)}
                             onSave={() => handleSave("email")}
+                            onCancel={() => handleCancel("email")}
                             disabled={!!user?.pending_email}
                         />
                         <ThemeSelectorRow

--- a/Frontend-nextjs/app/(protected)/profilo/components/ProfileRow.tsx
+++ b/Frontend-nextjs/app/(protected)/profilo/components/ProfileRow.tsx
@@ -71,25 +71,23 @@ export default function ProfileRow({
                         >
                             Salva
                         </button>
-                        {onCancel && (
-                            <button
-                                type="button"
-                                className="ml-1 p-2 rounded-full flex items-center justify-center transition hover:bg-red-100"
-                                onClick={onCancel}
-                                title="Annulla modifiche"
+                        <button
+                            type="button"
+                            className="ml-1 p-2 rounded-full flex items-center justify-center transition hover:bg-red-100"
+                            onClick={onCancel}
+                            title="Annulla modifiche"
+                        >
+                            {/* X svg semplice */}
+                            <svg
+                                viewBox="0 0 20 20"
+                                fill="none"
+                                className="w-4 h-4 text-red-500"
+                                stroke="currentColor"
+                                strokeWidth={2}
                             >
-                                {/* X svg semplice */}
-                                <svg
-                                    viewBox="0 0 20 20"
-                                    fill="none"
-                                    className="w-4 h-4 text-red-500"
-                                    stroke="currentColor"
-                                    strokeWidth={2}
-                                >
-                                    <path d="M6 6l8 8M6 14L14 6" strokeLinecap="round" />
-                                </svg>
-                            </button>
-                        )}
+                                <path d="M6 6l8 8M6 14L14 6" strokeLinecap="round" />
+                            </svg>
+                        </button>
                     </>
                 ) : (
                     <button

--- a/Frontend-nextjs/types/profilo/row.ts
+++ b/Frontend-nextjs/types/profilo/row.ts
@@ -5,7 +5,7 @@ export type RowProps = {
     onEdit: () => void;
     onChange: (v: string) => void;
     onSave: () => void;
-    onCancel?: () => void;
+    onCancel: () => void;
     type?: "text" | "select";
     options?: { value: string; label: string }[];
     disabled?: boolean;


### PR DESCRIPTION
## Summary
- add local backup state to ProfilePage and restore old value on cancel
- always show cancel button in ProfileRow while editing
- make RowProps require onCancel handler

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68935bc5aee88324b648852d5907d7c4