### PR TITLE
Protect demo user from account modifications

### DIFF
--- a/Backend/Modules/User/Http/Controllers/ApiResetPasswordController.php
+++ b/Backend/Modules/User/Http/Controllers/ApiResetPasswordController.php
@@ -22,6 +22,10 @@ class ApiResetPasswordController extends Controller
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
         ]);
 
+        if ($request->email === 'demo@synapsy.app') {
+            return ApiResponse::error("L'utente demo non può essere modificato", null, 403);
+        }
+
         $status = Password::reset(
             $request->only('email', 'password', 'password_confirmation', 'token'),
             function (User $user) use ($request) {

--- a/Backend/Modules/User/Routes/api.php
+++ b/Backend/Modules/User/Routes/api.php
@@ -55,12 +55,14 @@ Route::prefix('v1')->group(function () {
     Route::middleware('auth:sanctum')->group(function () {
         Route::post('logout', [ApiLoginController::class, 'logout']);
         Route::get('me', fn(Request $r) => $r->user())->name('me.show');
-        Route::apiResource('users', UserController::class)->names('users');
+        Route::middleware('block-demo-user')->group(function () {
+            Route::apiResource('users', UserController::class)->names('users');
+            Route::put('profile', [ProfileController::class, 'update'])->name('profile.update');
+            Route::delete('profile/pending-email', [ProfileController::class, 'cancelPendingEmail'])->name('profile.pending-email.cancel');
+            Route::post('profile/pending-email/resend', [ProfileController::class, 'resendPendingEmail'])->name('profile.pending-email.resend');
+            Route::delete('profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+        });
         Route::get('profile', [ProfileController::class, 'show'])->name('profile.show');
-        Route::put('profile', [ProfileController::class, 'update'])->name('profile.update');
-        Route::delete('profile/pending-email', [ProfileController::class, 'cancelPendingEmail'])->name('profile.pending-email.cancel');
-        Route::post('profile/pending-email/resend', [ProfileController::class, 'resendPendingEmail'])->name('profile.pending-email.resend');
-        Route::delete('profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
         Route::get('dashboard', [DashboardController::class, 'index'])->name('dashboard.index');
     });
 });

--- a/Backend/Modules/User/Routes/auth.php
+++ b/Backend/Modules/User/Routes/auth.php
@@ -54,7 +54,7 @@ Route::middleware('auth')->group(function () {
 
     Route::post('confirm-password', [ConfirmablePasswordController::class, 'store']);
 
-    Route::put('password', [PasswordController::class, 'update'])->name('password.update');
+    Route::put('password', [PasswordController::class, 'update'])->name('password.update')->middleware('block-demo-user');
 
     Route::post('logout', [AuthenticatedSessionController::class, 'destroy'])
         ->name('logout');

--- a/Backend/Modules/User/Routes/web.php
+++ b/Backend/Modules/User/Routes/web.php
@@ -16,7 +16,7 @@ Route::middleware(['web'])->group(function () {
         ->name('dashboard');
 
     // Rotte profilo e altro
-    Route::middleware(['auth', 'verified'])->group(function () {
+    Route::middleware(['auth', 'verified', 'block-demo-user'])->group(function () {
         Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
         Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
         Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');

--- a/Backend/app/Http/Middleware/PreventDemoUserModification.php
+++ b/Backend/app/Http/Middleware/PreventDemoUserModification.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use ApiResponse;
+
+class PreventDemoUserModification
+{
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $user = $request->user();
+
+        if ($user && $user->email === 'demo@synapsy.app' && !in_array($request->method(), ['GET', 'HEAD'])) {
+            $message = "L'utente demo non può essere modificato";
+            return $request->expectsJson()
+                ? ApiResponse::error($message, null, 403)
+                : abort(403, $message);
+        }
+
+        return $next($request);
+    }
+}

--- a/Backend/bootstrap/app.php
+++ b/Backend/bootstrap/app.php
@@ -13,6 +13,10 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up'
     )
     ->withMiddleware(function (Middleware $middleware) {
+        $middleware->alias([
+            'block-demo-user' => \App\Http\Middleware\PreventDemoUserModification::class,
+        ]);
+
         $middleware->group('web', [
             \Illuminate\Http\Middleware\HandleCors::class,
             \Illuminate\Cookie\Middleware\EncryptCookies::class,

--- a/Backend/tests/Feature/DemoUserProtectionTest.php
+++ b/Backend/tests/Feature/DemoUserProtectionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Modules\User\Models\User;
+use Tests\TestCase;
+
+class DemoUserProtectionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function createDemoUser(): User
+    {
+        return User::factory()->create([
+            'email' => 'demo@synapsy.app',
+            'password' => Hash::make('password1234'),
+            'email_verified_at' => now(),
+        ]);
+    }
+
+    public function test_demo_user_cannot_update_profile(): void
+    {
+        $user = $this->createDemoUser();
+        Sanctum::actingAs($user, ['*']);
+
+        $response = $this->putJson('/api/v1/profile', ['name' => 'New Name']);
+
+        $response->assertStatus(403);
+    }
+
+    public function test_demo_user_cannot_delete_profile(): void
+    {
+        $user = $this->createDemoUser();
+        Sanctum::actingAs($user, ['*']);
+
+        $response = $this->deleteJson('/api/v1/profile', ['password' => 'password1234']);
+
+        $response->assertStatus(403);
+    }
+
+    public function test_demo_user_cannot_change_password(): void
+    {
+        $user = $this->createDemoUser();
+        $this->actingAs($user);
+
+        $response = $this->put('/password', [
+            'current_password' => 'password1234',
+            'password' => 'newpassword',
+            'password_confirmation' => 'newpassword',
+        ]);
+
+        $response->assertStatus(403);
+    }
+}

--- a/Frontend-nextjs/app/(protected)/profilo/ProfilePage.tsx
+++ b/Frontend-nextjs/app/(protected)/profilo/ProfilePage.tsx
@@ -30,6 +30,8 @@ export default function ProfilePage() {
     const [backup, setBackup] = useState<Partial<UserType>>({});
     const [showPicker, setShowPicker] = useState(false);
 
+    const isDemo = user?.email === "demo@synapsy.app";
+
     useEffect(() => {
         if (user) setForm(user);
     }, [user]);
@@ -65,6 +67,11 @@ export default function ProfilePage() {
 
     return (
         <div className="max-w-3xl mx-auto">
+            {isDemo && (
+                <div className="mb-4 p-3 text-sm text-center rounded-xl bg-yellow-100 text-yellow-800">
+                    Questo è un account demo. I dati non possono essere modificati.
+                </div>
+            )}
             <PendingEmailNotice />
             {/* ───────────────────────────── */}
             {/*   DUE COLONNE SU MD+         */}
@@ -72,33 +79,36 @@ export default function ProfilePage() {
             <div className="flex flex-col md:flex-row md:items-start md:gap-8">
                 {/* -------- Colonna avatar -------- */}
                 <div className="flex justify-center md:justify-start md:min-w-[160px] md:pt-4">
-                    <motion.div whileHover={{ scale: 1.07 }} className="relative group">
+                    <motion.div whileHover={isDemo ? {} : { scale: 1.07 }} className="relative group">
                         <img
                             src={avatarUrl}
                             alt="Avatar"
-                            className="w-50 h-72 rounded-full object-cover border-2 cursor-pointer shadow transition group-hover:ring-2"
+                            className="w-50 h-72 rounded-full object-cover border-2 shadow transition group-hover:ring-2"
                             style={{
                                 borderColor: "hsl(var(--c-primary, 205 66% 49%))",
                                 boxShadow: "0 2px 12px 0 hsl(var(--c-primary-shadow, 205 66% 49% / 0.09))",
+                                cursor: isDemo ? "not-allowed" : "pointer",
                             }}
-                            onClick={() => setShowPicker(true)}
+                            onClick={isDemo ? undefined : () => setShowPicker(true)}
                             title="Cambia avatar"
                         />
                         {/* Badge matita (edit) */}
-                        <button
-                            type="button"
-                            className="absolute bottom-0 right-0 shadow px-1.5 py-0.5 rounded-full text-xs font-semibold opacity-85 hover:opacity-100 transition border"
-                            style={{
-                                background: "hsl(var(--c-bg, 44 81% 94%))",
-                                borderColor: "hsl(var(--c-primary-border, 205 66% 49% / 0.16))",
-                                color: "hsl(var(--c-primary, 205 66% 49%))",
-                            }}
-                            onClick={() => setShowPicker(true)}
-                            tabIndex={-1}
-                            title="Cambia avatar"
-                        >
-                            ✎
-                        </button>
+                        {!isDemo && (
+                            <button
+                                type="button"
+                                className="absolute bottom-0 right-0 shadow px-1.5 py-0.5 rounded-full text-xs font-semibold opacity-85 hover:opacity-100 transition border"
+                                style={{
+                                    background: "hsl(var(--c-bg, 44 81% 94%))",
+                                    borderColor: "hsl(var(--c-primary-border, 205 66% 49% / 0.16))",
+                                    color: "hsl(var(--c-primary, 205 66% 49%))",
+                                }}
+                                onClick={() => setShowPicker(true)}
+                                tabIndex={-1}
+                                title="Cambia avatar"
+                            >
+                                ✎
+                            </button>
+                        )}
                     </motion.div>
                 </div>
 
@@ -129,6 +139,7 @@ export default function ProfilePage() {
                             onChange={(v) => handleChange("name", v)}
                             onSave={() => handleSave("name")}
                             onCancel={() => handleCancel("name")}
+                            disabled={isDemo}
                         />
                         <ProfileRow
                             label="Cognome"
@@ -138,6 +149,7 @@ export default function ProfilePage() {
                             onChange={(v) => handleChange("surname", v)}
                             onSave={() => handleSave("surname")}
                             onCancel={() => handleCancel("surname")}
+                            disabled={isDemo}
                         />
                         <ProfileRow
                             label="Username"
@@ -147,6 +159,7 @@ export default function ProfilePage() {
                             onChange={(v) => handleChange("username", v)}
                             onSave={() => handleSave("username")}
                             onCancel={() => handleCancel("username")}
+                            disabled={isDemo}
                         />
                         <ProfileRow
                             label="Email"
@@ -156,7 +169,7 @@ export default function ProfilePage() {
                             onChange={(v) => handleChange("email", v)}
                             onSave={() => handleSave("email")}
                             onCancel={() => handleCancel("email")}
-                            disabled={!!user?.pending_email}
+                            disabled={isDemo || !!user?.pending_email}
                         />
                         <ThemeSelectorRow
                             value={form.theme}
@@ -168,6 +181,7 @@ export default function ProfilePage() {
                                 setEditing((e) => ({ ...e, theme: false }));
                             }}
                             onCancel={() => setEditing((e) => ({ ...e, theme: false }))}
+                            disabled={isDemo}
                         />
                     </div>
                 </div>
@@ -176,7 +190,7 @@ export default function ProfilePage() {
             {/* Modale scelta avatar          */}
             {/* ───────────────────────────── */}
             <AnimatePresence>
-                {showPicker && (
+                {showPicker && !isDemo && (
                     <AvatarPickerModal
                         selected={form.avatar}
                         onSelect={handleAvatarChange}

--- a/Frontend-nextjs/app/(protected)/profilo/components/DeleteAccountSection.tsx
+++ b/Frontend-nextjs/app/(protected)/profilo/components/DeleteAccountSection.tsx
@@ -21,6 +21,8 @@ export default function DeleteAccountSection() {
     const [password, setPassword] = useState("");
     const [loading, setLoading] = useState(false);
 
+    const isDemo = session?.user?.email === "demo@synapsy.app";
+
     const handleDelete = async () => {
         if (!session?.accessToken) return;
         setLoading(true);
@@ -34,6 +36,14 @@ export default function DeleteAccountSection() {
             setLoading(false);
         }
     };
+
+    if (isDemo) {
+        return (
+            <p className="text-center text-sm text-muted-foreground mt-6 mb-6">
+                L'utente demo non può eliminare il profilo.
+            </p>
+        );
+    }
 
     return (
         <div className="flex justify-end text-center mt-6 mb-6">

--- a/Frontend-nextjs/app/(protected)/profilo/components/ThemeSelectorRow.tsx
+++ b/Frontend-nextjs/app/(protected)/profilo/components/ThemeSelectorRow.tsx
@@ -4,7 +4,7 @@ import { useThemeContext } from "@/context/contexts/ThemeContext";
 import { themeMeta, availableThemes } from "@/lib/themeUtils";
 import { ThemeSelectorRowProps } from "@/types/profilo/row";
 
-export default function ThemeSelectorRow({ value, editing, onEdit, onSave, onCancel }: ThemeSelectorRowProps) {
+export default function ThemeSelectorRow({ value, editing, onEdit, onSave, onCancel, disabled = false }: ThemeSelectorRowProps) {
     const { theme } = useThemeContext();
     const [open, setOpen] = useState(false);
     const buttonRef = useRef<HTMLButtonElement>(null);
@@ -58,8 +58,11 @@ export default function ThemeSelectorRow({ value, editing, onEdit, onSave, onCan
                         style={{
                             background: "hsl(var(--c-secondary, 220 15% 48%))",
                             color: "hsl(var(--c-bg, 44 81% 94%))",
+                            opacity: disabled ? 0.4 : undefined,
+                            pointerEvents: disabled ? "none" : undefined,
                         }}
                         onClick={onEdit}
+                        disabled={disabled}
                     >
                         Modifica
                     </button>

--- a/Frontend-nextjs/app/components/PendingEmailNotice.tsx
+++ b/Frontend-nextjs/app/components/PendingEmailNotice.tsx
@@ -7,6 +7,7 @@ import ConfirmDialog from "@/app/components/ui/ConfirmDialog";
 
 export default function PendingEmailNotice() {
     const { user, cancelPending, resendPending } = useUser();
+    const isDemo = user?.email === "demo@synapsy.app";
 
     // Stato per la dialog di conferma
     const [showConfirm, setShowConfirm] = useState(false);
@@ -41,16 +42,20 @@ export default function PendingEmailNotice() {
                         </p>
                         <div className="flex gap-2">
                             <motion.button
-                                whileHover={{ scale: 1.05, opacity: 0.9 }}
+                                whileHover={isDemo ? {} : { scale: 1.05, opacity: 0.9 }}
                                 className="px-2 py-1 rounded-xl shadow bg-red-500 text-white text-xs font-semibold"
                                 onClick={handleCancel}
+                                disabled={isDemo}
+                                style={{ opacity: isDemo ? 0.5 : undefined, pointerEvents: isDemo ? "none" : undefined }}
                             >
                                 Annulla richiesta
                             </motion.button>
                             <motion.button
-                                whileHover={{ scale: 1.05, opacity: 0.9 }}
+                                whileHover={isDemo ? {} : { scale: 1.05, opacity: 0.9 }}
                                 className="px-2 py-1 rounded-xl shadow bg-blue-500 text-white text-xs font-semibold"
                                 onClick={handleResend}
+                                disabled={isDemo}
+                                style={{ opacity: isDemo ? 0.5 : undefined, pointerEvents: isDemo ? "none" : undefined }}
                             >
                                 Reinvia email
                             </motion.button>

--- a/Frontend-nextjs/types/profilo/row.ts
+++ b/Frontend-nextjs/types/profilo/row.ts
@@ -17,4 +17,5 @@ export type ThemeSelectorRowProps = {
     onEdit: () => void;
     onSave: (val: string) => void;
     onCancel: () => void;
+    disabled?: boolean;
 };


### PR DESCRIPTION
## Summary
- add middleware to reject profile updates and deletions for demo@synapsy.app
- guard profile/password routes with demo middleware and prevent password reset for demo
- disable profile edit UI for demo user and show notice

## Testing
- `php artisan test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894b0927fc48324aa01fdd62e1bb03c