### PR TITLE
docs: refine site structure and theme documentation

### DIFF
--- a/Backend/docs/README.md
+++ b/Backend/docs/README.md
@@ -24,6 +24,11 @@ php artisan serve
 
 ---
 
+## 🔒 Protezione utente demo
+Un middleware centralizzato (`PreventDemoUserModification`) blocca qualsiasi richiesta di scrittura per l'utente `demo@synapsy.app`. Il middleware è registrato in `bootstrap/app.php` e applicato a rotte API, web, auth e reset password. Test automatici in `tests/Feature/DemoUserProtectionTest.php` verificano il blocco.
+
+---
+
 ## 📚 Documentazione
 - [📜 Rotte API](API_ROUTES.md)
 - [🔐 Autenticazione](AUTH_FLOW.md)

--- a/Frontend-nextjs/docs/COMPONENTS.md
+++ b/Frontend-nextjs/docs/COMPONENTS.md
@@ -1,25 +1,32 @@
-# 🧩 Components
+# 🧩 Componenti
 
-Panoramica dei principali componenti UI.
+Panoramica sintetica dei componenti principali. Per l'associazione completa pagina/componente vedi [SITE_STRUCTURE.md](SITE_STRUCTURE.md).
 
----
+## Generali
+- Layout (header, sidebar)
+- Dialog & ModalLayout
+- Input, Button
 
-## Layout
-Wrappa tutte le pagine e gestisce header e sidebar.
+## Home
+- HeroCarousel
+- CategorieCard, TransazioniCard, RicorrentiCard, ProssimoPagamentoCard
+- NewTransactionButton, NewRicorrenzaButton, NewCategoryButton
 
-## Dashboard
-Mostra grafici e riepiloghi finanziari.
+## Transazioni
+- TransactionsList
+- SelectionToolbar
+- TransactionDetailModal
 
-## Calendar
-Calendario interattivo per visualizzare operazioni.
+## Ricorrenti
+- CardTotaliAnnui, CardGraficoPagamenti
+- ListaRicorrenzePerFrequenza, ListaProssimiPagamenti
+- NewRicorrenzaModal
 
-## Modals
-Componenti riutilizzabili per creare/modificare entrate e spese.
+## Categorie
+- CategoriesList
+- NewCategoryModal
+- DeleteCategoryModal
 
----
-Esempio utilizzo:
-```tsx
-<Modal onClose={...}>
-  <ExpenseForm />
-</Modal>
-```
+## Profilo
+- ProfileRow, ThemeSelectorRow, AvatarSelector
+- AvatarPickerModal, DeleteAccountSection

--- a/Frontend-nextjs/docs/README.md
+++ b/Frontend-nextjs/docs/README.md
@@ -12,6 +12,21 @@ Interfaccia Next.js/React per la gestione finanziaria collegata alle API Laravel
 
 ---
 
+## 📄 Struttura pagine
+L'alberatura completa con componenti e modali è descritta in [SITE_STRUCTURE.md](SITE_STRUCTURE.md).
+
+Pagine principali:
+- `/` Home
+- `/transazioni`
+- `/ricorrenti`
+- `/categorie`
+- `/panoramica`
+- `/profilo`
+- `/login`
+- `/reset-password`
+
+---
+
 ## 🚀 Avvio rapido
 ```bash
 cd Frontend-nextjs
@@ -31,6 +46,12 @@ L'app è disponibile su [http://localhost:3000](http://localhost:3000)
 - [🧪 Testing](TESTING.md)
 - [🔄 Workflows](WORKFLOWS.md)
 - [🚀 Deploy](DEPLOY.md)
+- [🗺️ Struttura del sito](SITE_STRUCTURE.md)
+
+---
+
+## 🔒 Protezione utente demo
+Le operazioni di scrittura sono bloccate per l'utente demo. L'interfaccia mostra un avviso e disabilita i controlli (tema, avatar, eliminazione account). Feature introdotta nel commit `426d9c0` con il middleware `PreventDemoUserModification` e gli aggiornamenti in `ProfilePage.tsx`.
 
 ---
 

--- a/Frontend-nextjs/docs/SITE_STRUCTURE.md
+++ b/Frontend-nextjs/docs/SITE_STRUCTURE.md
@@ -1,0 +1,50 @@
+# 🗺️ Struttura del Sito
+
+Elenco delle pagine effettive con i principali componenti e modali associati.
+
+## Albero pagine
+
+/ (root)
+- HomePage
+  - HeroCarousel
+  - TransazioniCard
+  - RicorrentiCard
+  - CategorieCard
+  - ProssimoPagamentoCard
+  - Modali:
+    - NewTransactionModal (da NewTransactionButton)
+    - NewRicorrenzaModal (da NewRicorrenzaButton)
+    - NewCategoryModal (da NewCategoryButton)
+- TransazioniPage
+  - TransactionsList
+  - SelectionToolbar
+  - Modal: TransactionDetailModal (clic su transazione)
+- RicorrentiPage
+  - CardTotaliAnnui
+  - CardGraficoPagamenti
+  - ListaRicorrenzePerFrequenza
+  - ListaProssimiPagamenti
+  - AreaGraficiRicorrenze
+  - Modal: NewRicorrenzaModal (context `openModal`)
+- CategoriePage
+  - CategoriesList
+  - Modali:
+    - NewCategoryModal (da NewCategoryButton)
+    - DeleteCategoryModal (dalla lista)
+- PanoramicaPage
+  - CalendarGrid
+- ProfiloPage
+  - ProfileRow
+  - ThemeSelectorRow
+  - AvatarSelector
+  - Modali:
+    - AvatarPickerModal (clic su avatar)
+    - DeleteAccountSection (Dialog di conferma)
+
+(auth)
+- LoginPage
+  - LoginForm
+- ResetPasswordPage
+  - ResetPasswordForm
+
+> Aggiornare questo file quando vengono aggiunte o rimosse pagine/modal.

--- a/Frontend-nextjs/docs/THEMES.md
+++ b/Frontend-nextjs/docs/THEMES.md
@@ -5,14 +5,20 @@ Gestione dei temi e personalizzazione.
 ---
 
 ## Temi disponibili
-- `light`
-- `dark`
-- `emerald`
+
+| Tema       | Sfondo (`--c-bg`)      | Testo (`--c-text`)      | Primario (`--c-primary`) |
+|------------|-----------------------|-------------------------|--------------------------|
+| `light`    | `hsl(220 20% 98%)`     | `hsl(220 17% 27%)`      | `hsl(120 34% 62%)`       |
+| `dark`     | `hsl(235 15% 10%)`     | `hsl(220 60% 96%)`      | `hsl(159 68% 54%)`       |
+| `emerald`  | `hsl(150 70% 97%)`     | `hsl(168 77% 26%)`      | `hsl(158 96% 24%)`       |
+| `solarized`| `hsl(44 81% 94%)`      | `hsl(193 14% 40%)`      | `hsl(205 66% 49%)`       |
+
+Le palette complete sono definite nei file `styles/themes/*.css` e importate da `styles/themes.css`.
 
 ## Variabili CSS
-Definite in `styles/globals.css` e configurate in `tailwind.config.ts`.
+Configurate in `styles/themes.css` e richiamate in `tailwind.config.ts`.
 
 ## Override
 ```css
-:root { --color-primary: #00ff00; }
+:root { --c-primary: #00ff00; }
 ```

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Gestione avanzata di entrate, spese e operazioni ricorrenti.
 
 -   [📦 Backend API](Backend/docs/README.md)
 -   [💻 Frontend Web](Frontend-nextjs/docs/README.md)
+-   [🗺️ Site Structure](Frontend-nextjs/docs/SITE_STRUCTURE.md)
 
 ---
 
@@ -55,6 +56,11 @@ npm run dev
 [https://synapsy-frontend.vercel.app/](https://synapsy-frontend.vercel.app/)
 
 > Puoi accedere in modalità demo per esplorare tutte le funzionalità senza registrazione!
+
+---
+
+## 🔒 Protezione utente demo
+Le operazioni di scrittura sono bloccate per l'utente demo tramite un middleware centralizzato (`PreventDemoUserModification`) applicato a rotte API, web e auth. La UI mostra un avviso e disabilita i controlli di modifica (tema, avatar, eliminazione account). Feature introdotta nel commit `426d9c0`.
 
 ---
 


### PR DESCRIPTION
## Summary
- document full Next.js page tree with components and modals
- expand theme guide to include Solarized palette and main colors
- describe demo-user protection in root, backend, and frontend READMEs

## Testing
- `php artisan test`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6894b4f3d06c8324aa03994767f11ad7