### PR TITLE
chore: centralize API prefix

### DIFF
--- a/Mobile/src/context/AuthContext.tsx
+++ b/Mobile/src/context/AuthContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useState, useContext, useEffect } from "react";
 import * as SecureStore from "expo-secure-store";
 import api, { setAuthToken, registerInterceptor } from "../lib/api";
+import { API_PREFIX } from "../lib/apiPrefix";
 import { User } from "../types";
 
 type AuthContextType = {
@@ -33,12 +34,12 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
     const login = async (email: string, password: string) => {
         setLoading(true);
-        const { data } = await api.post("/v1/login", { email, password });
+        const { data } = await api.post(`${API_PREFIX}/login`, { email, password });
         const accessToken = data.token;
         setToken(accessToken);
         setAuthToken(accessToken);
         await SecureStore.setItemAsync("token", accessToken);
-        const me = await api.get("/v1/me");
+        const me = await api.get(`${API_PREFIX}/me`);
         setUser(me.data);
         setLoading(false);
     };
@@ -49,7 +50,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
             setAuthToken(saved);
             setToken(saved);
             try {
-                const me = await api.get("/v1/me");
+                const me = await api.get(`${API_PREFIX}/me`);
                 setUser(me.data);
             } catch (e) {
                 logout();

--- a/Mobile/src/lib/api.ts
+++ b/Mobile/src/lib/api.ts
@@ -8,6 +8,7 @@
 import axios, { AxiosError } from "axios";
 import { Platform } from "react-native";
 import { getEnv } from "./env";
+import { API_PREFIX } from "./apiPrefix";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // 1) Normalizza la BASE URL
@@ -110,7 +111,7 @@ export const registerInterceptor = (logout: () => void) => {
 export async function ping() {
     // se la tua API ha /health oppure /api/health, cambialo qui
     return api
-        .get("/health")
+        .get(`${API_PREFIX}/health`)
         .then((r) => r.data)
         .catch((e) => {
             throw e;

--- a/Mobile/src/lib/apiPrefix.ts
+++ b/Mobile/src/lib/apiPrefix.ts
@@ -1,0 +1,7 @@
+// ─────────────────────────────────────────────────────────────────────────
+// SCEGLI UNA SOLA OPZIONE:
+// Opzione A: baseURL = .../api  → API_PREFIX = '/v1'
+// Opzione B: baseURL = .../api/v1 → API_PREFIX = ''
+// ─────────────────────────────────────────────────────────────────────────
+export const API_PREFIX = '/v1'; // default: Opzione A
+// export const API_PREFIX = '';  // usa questa se il progetto è in Opzione B


### PR DESCRIPTION
## Summary
- add API_PREFIX constant
- use API_PREFIX for auth calls and health check

## Testing
- `npm test` (fails: jest: not found)
- `npm run lint` (fails: ESLint couldn't find configuration file)

------
https://chatgpt.com/codex/tasks/task_e_68a0c26d8994832489294d434840f8a6