### PR TITLE
chore(mobile): allinea tutte le chiamate API a /api/v1 con API_PREFIX, normalizza liste e fissa login flow (Bearer)

### DIFF
--- a/Mobile/src/features/_debug/quickProbe.ts
+++ b/Mobile/src/features/_debug/quickProbe.ts
@@ -1,0 +1,16 @@
+// ──────────────────────────────────────────────────
+// Probe veloce in DEV
+// ──────────────────────────────────────────────────
+import { listSpese } from "@/features/spese/api";
+import { listEntrate } from "@/features/entrate/api";
+
+export async function quickProbe() {
+    if (!__DEV__) return;
+    try {
+        const [spese, entrate] = await Promise.all([listSpese(1, 50), listEntrate(1, 50)]);
+        const merged = [...spese, ...entrate].slice(0, 3);
+        console.log("quickProbe", merged);
+    } catch (e) {
+        console.log("quickProbe error", e);
+    }
+}

--- a/Mobile/src/features/auth/api.ts
+++ b/Mobile/src/features/auth/api.ts
@@ -1,0 +1,17 @@
+// ──────────────────────────────────────────────────
+// Chiamate auth: login/logout/me
+// ──────────────────────────────────────────────────
+import api from "@/lib/api";
+import { API_PREFIX } from "@/lib/apiPrefix";
+
+export async function login(email: string, password: string) {
+    return api.post(`${API_PREFIX}/login`, { email, password }).then((r) => r.data);
+}
+
+export async function logout() {
+    return api.post(`${API_PREFIX}/logout`).then((r) => r.data);
+}
+
+export async function me() {
+    return api.get(`${API_PREFIX}/me`).then((r) => r.data);
+}

--- a/Mobile/src/features/categories/api.ts
+++ b/Mobile/src/features/categories/api.ts
@@ -1,0 +1,12 @@
+// ──────────────────────────────────────────────────
+// Service categories
+// ──────────────────────────────────────────────────
+import api from "@/lib/api";
+import { API_PREFIX } from "@/lib/apiPrefix";
+import { asList } from "@/lib/shape";
+
+export async function listCategories(page = 1, perPage = 20) {
+    return api
+        .get(`${API_PREFIX}/categories`, { params: { page, per_page: perPage } })
+        .then((r) => asList(r.data));
+}

--- a/Mobile/src/features/entrate/api.ts
+++ b/Mobile/src/features/entrate/api.ts
@@ -1,0 +1,12 @@
+// ──────────────────────────────────────────────────
+// Service entrate
+// ──────────────────────────────────────────────────
+import api from "@/lib/api";
+import { API_PREFIX } from "@/lib/apiPrefix";
+import { asList } from "@/lib/shape";
+
+export async function listEntrate(page = 1, perPage = 20) {
+    return api
+        .get(`${API_PREFIX}/entrate`, { params: { page, per_page: perPage } })
+        .then((r) => asList(r.data));
+}

--- a/Mobile/src/features/spese/api.ts
+++ b/Mobile/src/features/spese/api.ts
@@ -1,0 +1,12 @@
+// ──────────────────────────────────────────────────
+// Service spese
+// ──────────────────────────────────────────────────
+import api from "@/lib/api";
+import { API_PREFIX } from "@/lib/apiPrefix";
+import { asList } from "@/lib/shape";
+
+export async function listSpese(page = 1, perPage = 20) {
+    return api
+        .get(`${API_PREFIX}/spese`, { params: { page, per_page: perPage } })
+        .then((r) => asList(r.data));
+}

--- a/Mobile/src/lib/shape.ts
+++ b/Mobile/src/lib/shape.ts
@@ -1,0 +1,8 @@
+// ──────────────────────────────────────────────────
+// Helpers per uniformare le risposte API
+// ──────────────────────────────────────────────────
+export function asList<T = any>(payload: any): T[] {
+    if (Array.isArray(payload)) return payload;
+    if (payload?.data && Array.isArray(payload.data)) return payload.data;
+    return [];
+}


### PR DESCRIPTION
## Summary
- add API_PREFIX helper and service layer for auth, spese, entrate and categories
- normalize list responses with `asList` and add debug quickProbe
- refactor AuthContext to use service layer and Bearer token flow

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0dc11e9a4832483be3645f0ea2c48