### PR TITLE
feat(auth): secure token storage (native/web), axios refresh guard, clean interceptors

### DIFF
--- a/Mobile/src/lib/api.ts
+++ b/Mobile/src/lib/api.ts
@@ -1,26 +1,80 @@
 // src/lib/api.ts
 // ─────────────────────────────────────────────────────────────────────────────
-// Axios preconfigurato + token da SecureStore
+// Axios centralizzato: bearer header + auto-refresh (se disponibile)
 // ─────────────────────────────────────────────────────────────────────────────
-import axios from 'axios';
-import * as SecureStore from 'expo-secure-store';
+import axios, { AxiosError, AxiosRequestConfig } from 'axios';
 import { ENV } from './env';
+import {
+  getAccessToken, setAccessToken, clearTokens,
+  getRefreshToken, setRefreshToken
+} from './tokenStorage';
 
-export const TOKEN_KEY = 'synapsi_token';
-
+// ─── Istanza ─────────────────────────────────────────────────────────────────
 export const api = axios.create({
-  baseURL: ENV.API_BASE_URL,
-  timeout: 10000,
+  baseURL: ENV.API_BASE_URL,   // deve già includere /api/v1
+  timeout: 15000,
+  withCredentials: false,      // niente cookie su web → meno CORS
+  headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
 });
 
-// ── token interceptor ────────────────────────────────────────────────────────
-api.interceptors.request.use(async (config) => {
-  const token = await SecureStore.getItemAsync(TOKEN_KEY);
-  if (token) {
-    config.headers = config.headers ?? {};
-    config.headers[ENV.TOKEN_HEADER] = `Bearer ${token}`;
+// ─── Refresh guard (evita race) ──────────────────────────────────────────────
+let refreshing: Promise<string | null> | null = null;
+async function refreshAccessToken(): Promise<string | null> {
+  if (!ENV.REFRESH_PATH) return null;
+  const rt = await getRefreshToken();
+  if (!rt) return null;
+
+  if (!refreshing) {
+    refreshing = (async () => {
+      try {
+        // Preferisci header Bearer; fallback body {refresh_token}
+        const res = await axios.post(
+          ENV.API_BASE_URL + ENV.REFRESH_PATH,
+          { refresh_token: rt },
+          { headers: { [ENV.TOKEN_HEADER]: `Bearer ${rt}` } }
+        );
+        const newAccess = res.data?.access_token || res.data?.token;
+        const newRefresh = res.data?.refresh_token; // opzionale
+        if (newAccess) await setAccessToken(newAccess);
+        if (newRefresh) await setRefreshToken(newRefresh);
+        return newAccess ?? null;
+      } catch {
+        await clearTokens();
+        return null;
+      } finally {
+        refreshing = null;
+      }
+    })();
   }
-  return config;
+  return refreshing;
+}
+
+// ─── Request: attach bearer ──────────────────────────────────────────────────
+api.interceptors.request.use(async (cfg) => {
+  const t = await getAccessToken();
+  if (t) {
+    cfg.headers = cfg.headers ?? {};
+    cfg.headers[ENV.TOKEN_HEADER] = `Bearer ${t}`;
+  }
+  return cfg;
 });
 
-export type ApiResponse<T> = { data: T; message?: string };
+// ─── Response: 401 → tenta refresh una sola volta ────────────────────────────
+api.interceptors.response.use(
+  (r) => r,
+  async (err: AxiosError) => {
+    const original = err.config as (AxiosRequestConfig & { _retry?: boolean });
+    const status = err.response?.status;
+
+    if (status === 401 && !original?._retry) {
+      original._retry = true;
+      const newAccess = await refreshAccessToken();
+      if (newAccess) {
+        original.headers = original.headers ?? {};
+        original.headers[ENV.TOKEN_HEADER] = `Bearer ${newAccess}`;
+        return api.request(original);
+      }
+    }
+    throw err;
+  }
+);

--- a/Mobile/src/lib/env.ts
+++ b/Mobile/src/lib/env.ts
@@ -1,13 +1,14 @@
 // src/lib/env.ts
 // ─────────────────────────────────────────────────────────────────────────────
-// Lettura sicura ENV da Expo config
+// Expo extra → ENV tipizzato
 // ─────────────────────────────────────────────────────────────────────────────
 import Constants from 'expo-constants';
 
 type Extra = {
   APP_ENV: string;
-  API_BASE_URL: string;
-  TOKEN_HEADER: string;
+  API_BASE_URL: string;   // Deve già includere /api/v1 (es: http://192.168.0.111:8484/api/v1)
+  TOKEN_HEADER: string;   // "Authorization"
+  REFRESH_PATH?: string;  // opzionale (es: "/refresh")
 };
 
 const extra = (Constants.expoConfig?.extra ?? {}) as Partial<Extra>;
@@ -16,8 +17,7 @@ export const ENV: Extra = {
   APP_ENV: extra.APP_ENV ?? 'local',
   API_BASE_URL: extra.API_BASE_URL ?? 'http://localhost:8484/api/v1',
   TOKEN_HEADER: extra.TOKEN_HEADER ?? 'Authorization',
+  REFRESH_PATH: extra.REFRESH_PATH ?? '/refresh', // usato solo se esiste lato backend
 };
-
-// ── util ─────────────────────────────────────────────────────────────────────
 export const isProd = ENV.APP_ENV === 'production';
 export const isDev  = !isProd;

--- a/Mobile/src/lib/tokenStorage.ts
+++ b/Mobile/src/lib/tokenStorage.ts
@@ -1,0 +1,54 @@
+// src/lib/tokenStorage.ts
+// ─────────────────────────────────────────────────────────────────────────────
+// Storage token: SecureStore (native) + sessionStorage (web) + fallback in-mem
+// ─────────────────────────────────────────────────────────────────────────────
+import { Platform } from 'react-native';
+import * as SecureStore from 'expo-secure-store';
+
+const ACCESS_KEY  = 'synapsi_access';
+const REFRESH_KEY = 'synapsi_refresh';
+
+let memAccess: string | null = null;
+let memRefresh: string | null = null;
+
+const isWeb = Platform.OS === 'web';
+const webStore = isWeb && typeof window !== 'undefined' ? window.sessionStorage : null;
+
+// ─── Access Token ────────────────────────────────────────────────────────────
+export async function getAccessToken() {
+  if (isWeb && webStore) return webStore.getItem(ACCESS_KEY);
+  const v = await SecureStore.getItemAsync(ACCESS_KEY);
+  return v ?? memAccess;
+}
+export async function setAccessToken(t: string) {
+  memAccess = t;
+  if (isWeb && webStore) webStore.setItem(ACCESS_KEY, t);
+  else await SecureStore.setItemAsync(ACCESS_KEY, t);
+}
+export async function removeAccessToken() {
+  memAccess = null;
+  if (isWeb && webStore) webStore.removeItem(ACCESS_KEY);
+  else await SecureStore.deleteItemAsync(ACCESS_KEY);
+}
+
+// ─── Refresh Token ───────────────────────────────────────────────────────────
+export async function getRefreshToken() {
+  if (isWeb && webStore) return webStore.getItem(REFRESH_KEY);
+  const v = await SecureStore.getItemAsync(REFRESH_KEY);
+  return v ?? memRefresh;
+}
+export async function setRefreshToken(t: string) {
+  memRefresh = t;
+  if (isWeb && webStore) webStore.setItem(REFRESH_KEY, t);
+  else await SecureStore.setItemAsync(REFRESH_KEY, t);
+}
+export async function removeRefreshToken() {
+  memRefresh = null;
+  if (isWeb && webStore) webStore.removeItem(REFRESH_KEY);
+  else await SecureStore.deleteItemAsync(REFRESH_KEY);
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+export async function clearTokens() {
+  await Promise.all([removeAccessToken(), removeRefreshToken()]);
+}


### PR DESCRIPTION
## Summary
- add typed env config with optional refresh path
- implement SecureStore + sessionStorage token manager
- centralize axios client with refresh guard and interceptors
- refactor auth context to use new token storage

## Testing
- `npm test`
- `npm run lint`
- `npx expo start --web -c`

------
https://chatgpt.com/codex/tasks/task_e_68a0eb2ceab88324835d0cb3a26e813e