### PR TITLE
docs: map database schema and tidy backend models

### DIFF
--- a/Backend/Modules/Categories/Models/Category.php
+++ b/Backend/Modules/Categories/Models/Category.php
@@ -1,9 +1,15 @@
 <?php
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Sezione: Modello Category
+// Dettagli: categorie per transazioni, con scope di utilità
+// ─────────────────────────────────────────────────────────────────────────────
+
 namespace Modules\Categories\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Modules\Categories\Database\Factories\CategoryFactory;
 use Modules\User\Models\User;
@@ -17,7 +23,6 @@ use Modules\User\Models\User;
  * @property string $type
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
- *
  * @property-read User $user
  *
  * @method static CategoryFactory factory($count = null, array $state = [])
@@ -51,8 +56,6 @@ class Category extends Model
 
     protected $casts = [
         'type' => 'string',
-        'color',
-        'icon',
     ];
 
     // ============================
@@ -62,6 +65,20 @@ class Category extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    // ===================================================================
+    // Local Scopes
+    // ===================================================================
+
+    public function scopeOfUser(Builder $query, int $userId): Builder
+    {
+        return $query->where('user_id', $userId);
+    }
+
+    public function scopeOfType(Builder $query, string $type): Builder
+    {
+        return $query->where('type', $type);
     }
 
     // ============================
@@ -87,4 +104,3 @@ class Category extends Model
         return CategoryFactory::new();
     }
 }
-

--- a/Backend/Modules/Entrate/Models/Entrata.php
+++ b/Backend/Modules/Entrate/Models/Entrata.php
@@ -1,12 +1,18 @@
 <?php
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Sezione: Modello Entrata
+// Dettagli: rappresenta una singola entrata e include scope comuni
+// ─────────────────────────────────────────────────────────────────────────────
+
 namespace Modules\Entrate\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Modules\User\Models\User;
 use Modules\Categories\Models\Category;
+use Modules\User\Models\User;
 
 /**
  * Modello per le entrate.
@@ -20,7 +26,6 @@ use Modules\Categories\Models\Category;
  * @property string|null $notes
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
- *
  * @property-read User $user
  * @property-read Category|null $category
  *
@@ -61,7 +66,7 @@ class Entrata extends Model
     {
         return [
             'amount' => 'float',
-            'date'   => 'date',
+            'date' => 'date',
         ];
     }
 
@@ -77,6 +82,20 @@ class Entrata extends Model
     public function category(): BelongsTo
     {
         return $this->belongsTo(Category::class);
+    }
+
+    // ===================================================================
+    // Local Scopes
+    // ===================================================================
+
+    public function scopeOfUser(Builder $query, int $userId): Builder
+    {
+        return $query->where('user_id', $userId);
+    }
+
+    public function scopeBetweenDates(Builder $query, string $from, string $to): Builder
+    {
+        return $query->whereBetween('date', [$from, $to]);
     }
 
     // ============================
@@ -98,4 +117,3 @@ class Entrata extends Model
     //     return number_format($this->amount, 2) . ' €';
     // }
 }
-

--- a/Backend/Modules/Entrate/Services/EntrateService.php
+++ b/Backend/Modules/Entrate/Services/EntrateService.php
@@ -1,12 +1,17 @@
 <?php
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Sezione: Servizio Entrate
+// Dettagli: logica di business per la gestione delle entrate
+// ─────────────────────────────────────────────────────────────────────────────
+
 namespace Modules\Entrate\Services;
 
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Pagination\LengthAwarePaginator;
 use Modules\Entrate\Models\Entrata;
 use Modules\User\Models\User;
-use Illuminate\Pagination\LengthAwarePaginator;
 
 /**
  * Servizio per la gestione delle Entrate utente.
@@ -19,14 +24,20 @@ class EntrateService
     // ─────────────────────────────────────────────────────────────────────────
     public function listForUserPaginated($user, array $filters, string $sort, int $page, int $perPage): LengthAwarePaginator
     {
-        $q = Entrata::query()->where('user_id', $user->id);
+        $q = Entrata::query()->with('category')->where('user_id', $user->id);
 
-        if (!empty($filters['start_date'])) $q->whereDate('date', '>=', $filters['start_date']);
-        if (!empty($filters['end_date']))   $q->whereDate('date', '<=', $filters['end_date']);
-        if (!empty($filters['category_id'])) $q->where('category_id', $filters['category_id']);
-        if (!empty($filters['description'])) {
+        if (! empty($filters['start_date'])) {
+            $q->whereDate('date', '>=', $filters['start_date']);
+        }
+        if (! empty($filters['end_date'])) {
+            $q->whereDate('date', '<=', $filters['end_date']);
+        }
+        if (! empty($filters['category_id'])) {
+            $q->where('category_id', $filters['category_id']);
+        }
+        if (! empty($filters['description'])) {
             $term = $filters['description'];
-            $q->where(fn(Builder $qq) => $qq
+            $q->where(fn (Builder $qq) => $qq
                 ->where('description', 'like', "%{$term}%")
                 ->orWhere('notes', 'like', "%{$term}%"));
         }
@@ -36,9 +47,13 @@ class EntrateService
         foreach ($parts as $s) {
             $dir = str_starts_with($s, '-') ? 'desc' : 'asc';
             $col = ltrim($s, '-');
-            if (in_array($col, $allowed, true)) $q->orderBy($col, $dir);
+            if (in_array($col, $allowed, true)) {
+                $q->orderBy($col, $dir);
+            }
         }
-        if (empty($parts)) $q->orderBy('date', 'desc');
+        if (empty($parts)) {
+            $q->orderBy('date', 'desc');
+        }
 
         return $q->paginate($perPage, ['*'], 'page', $page);
     }
@@ -54,19 +69,19 @@ class EntrateService
     {
         $query = $user->entrate()->with('category');
 
-        if (!empty($filters['start_date'])) {
+        if (! empty($filters['start_date'])) {
             $query->whereDate('date', '>=', $filters['start_date']);
         }
 
-        if (!empty($filters['end_date'])) {
+        if (! empty($filters['end_date'])) {
             $query->whereDate('date', '<=', $filters['end_date']);
         }
 
-        if (!empty($filters['description'])) {
-            $query->where('description', 'like', '%' . $filters['description'] . '%');
+        if (! empty($filters['description'])) {
+            $query->where('description', 'like', '%'.$filters['description'].'%');
         }
 
-        if (!empty($filters['category_id'])) {
+        if (! empty($filters['category_id'])) {
             $validCategory = $user->categories()
                 ->where('type', 'entrata')
                 ->find($filters['category_id']);
@@ -106,10 +121,10 @@ class EntrateService
     {
         return $user->entrate()->create([
             'description' => $data['description'],
-            'amount'      => $data['amount'],
-            'date'        => $data['date'],
+            'amount' => $data['amount'],
+            'date' => $data['date'],
             'category_id' => $data['category_id'] ?? null,
-            'notes'       => $data['notes'] ?? null,
+            'notes' => $data['notes'] ?? null,
         ]);
     }
 
@@ -128,10 +143,10 @@ class EntrateService
     {
         return $entrata->update([
             'description' => $data['description'],
-            'amount'      => $data['amount'],
-            'date'        => $data['date'],
+            'amount' => $data['amount'],
+            'date' => $data['date'],
             'category_id' => $data['category_id'] ?? null,
-            'notes'       => $data['notes'] ?? null,
+            'notes' => $data['notes'] ?? null,
         ]);
     }
 

--- a/Backend/Modules/Spese/Models/Spesa.php
+++ b/Backend/Modules/Spese/Models/Spesa.php
@@ -1,18 +1,20 @@
 <?php
 
-namespace Modules\Spese\Models; // Namespace specifico del modulo Spese
+// ─────────────────────────────────────────────────────────────────────────────
+// Sezione: Modello Spesa
+// Dettagli: rappresenta una spesa utente con scope comuni
+// ─────────────────────────────────────────────────────────────────────────────
 
-use Illuminate\Database\Eloquent\Model; // Classe base per i modelli Eloquent
-use Illuminate\Database\Eloquent\Factories\HasFactory; // Trait per le Factory
-use Illuminate\Database\Eloquent\Relations\BelongsTo; // Classe per relazioni BelongsTo
+namespace Modules\Spese\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Modules\Categories\Models\Category;
 use Modules\User\Models\User;
-use Modules\Categories\Models\Category; // Importa il modello Category dal suo modulo
 
-// Il modello Spesa rappresenta una singola spesa finanziaria nel database.
-// Ogni spesa appartiene a un utente e può essere associata a una categoria.
 /**
- * 
- *
  * @property int $id
  * @property int $user_id
  * @property int|null $category_id
@@ -20,129 +22,66 @@ use Modules\Categories\Models\Category; // Importa il modello Category dal suo m
  * @property float $amount
  * @property \Illuminate\Support\Carbon $date
  * @property string|null $notes
- * @property \Illuminate\Support\Carbon|null $created_at
- * @property \Illuminate\Support\Carbon|null $updated_at
- * @property-read Category|null $category
  * @property-read User $user
- * @method static \Modules\Spese\Database\Factories\SpesaFactory factory($count = null, $state = [])
- * @method static \Illuminate\Database\Eloquent\Builder<static>|Spesa newModelQuery()
- * @method static \Illuminate\Database\Eloquent\Builder<static>|Spesa newQuery()
- * @method static \Illuminate\Database\Eloquent\Builder<static>|Spesa query()
- * @method static \Illuminate\Database\Eloquent\Builder<static>|Spesa whereAmount($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|Spesa whereCategoryId($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|Spesa whereCreatedAt($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|Spesa whereDate($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|Spesa whereDescription($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|Spesa whereId($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|Spesa whereNotes($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|Spesa whereUpdatedAt($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|Spesa whereUserId($value)
- * @mixin \Eloquent
+ * @property-read Category|null $category
  */
 class Spesa extends Model
 {
-    // Utilizza il trait HasFactory per associare questo modello alla sua Factory.
     use HasFactory;
 
-    /**
-     * Il nome della tabella associata al modello.
-     * Eloquent dedurrà  il nome 'spese' automaticamente, ma definirlo esplicitamente
-     * può essere utile per chiarezza o se il nome della tabella non segue la convenzione.
-     *
-     * @var string
-     */
     protected $table = 'spese';
 
-    /**
-     * Attributi che possono essere assegnati in massa (mass assignable).
-     * Definisce quali colonne possono essere riempite usando metodi come create() o fill().
-     *
-     * @var array<int, string>
-     */
     protected $fillable = [
-        'user_id',     // La chiave esterna all'utente
-        'category_id', // La chiave esterna alla categoria (può essere null)
-        'description', // Descrizione della spesa
-        'amount',      // Importo della spesa
-        'date',        // Data della spesa
-        'notes',       // Note aggiuntive (opzionale)
-        // 'created_at', // I timestamps sono gestiti automaticamente da Eloquent
-        // 'updated_at', // I timestamps sono gestiti automaticamente da Eloquent
+        'user_id',
+        'category_id',
+        'description',
+        'amount',
+        'date',
+        'notes',
     ];
 
-    /**
-     * Casting degli attributi a tipi specifici.
-     * Assicura che 'amount' sia trattato come float e 'date' come oggetto Carbon.
-     *
-     * @return array<string, string>
-     */
     protected function casts(): array
     {
         return [
-            'amount' => 'float', // Converte l'importo in float
-            'date' => 'date',    // Converte la data in un oggetto Carbon (solo data, senza ora)
-            // Se nella migrazione hai usato datetime per la data, usa 'datetime' qui.
-            // 'created_at' => 'datetime', // Esempi di casting per i timestamps (gestiti automaticamente)
-            // 'updated_at' => 'datetime',
+            'amount' => 'float',
+            'date' => 'date',
         ];
     }
 
+    // ===================================================================
+    // Relazioni
+    // ===================================================================
 
-    // =========================================================================
-    // SEZIONE: RELAZIONI
-    // Definisce le relazioni del modello Spesa con altri modelli.
-    // =========================================================================
-
-    /**
-     * Ottiene l'utente proprietario della spesa.
-     * Definisce una relazione Many-to-One (Molte spese appartengono a un utente).
-     * Laravel cercherà  una colonna 'user_id' nella tabella 'spese'.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
-     */
     public function user(): BelongsTo
     {
-        // Ritorna la relazione BelongsTo con il modello User.
-        // Laravel assumerà  che la chiave esterna sia 'user_id' e la chiave locale sia 'id' sul modello User.
         return $this->belongsTo(User::class);
     }
 
-    /**
-     * Ottiene la categoria associata alla spesa.
-     * Definisce una relazione Many-to-One (Molte spese possono avere la stessa categoria).
-     * Laravel cercherà una colonna 'category_id' nella tabella 'spese'.
-     * Questa relazione può essere null se category_id nella migrazione è nullable.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
-     */
     public function category(): BelongsTo
     {
-        // Ritorna la relazione BelongsTo con il modello Category.
-        // Laravel assumerà  che la chiave esterna sia 'category_id' e la chiave locale sia 'id' sul modello Category.
         return $this->belongsTo(Category::class);
     }
 
-    // =========================================================================
-    // SEZIONE: FACTORY
-    // Sovrascrive il metodo di default per specificare la Factory del modulo.
-    // =========================================================================
+    // ===================================================================
+    // Local Scopes
+    // ===================================================================
 
-    /**
-     * Crea una nuova istanza della factory associata al modello.
-     * Questo metodo sovrascrive il metodo di default fornito da HasFactory
-     * per specificare esplicitamente la Factory del modulo.
-     *
-     * @return \Illuminate\Database\Eloquent\Factories\Factory
-     */
-    protected static function newFactory(): \Illuminate\Database\Eloquent\Factories\Factory
+    public function scopeOfUser(Builder $query, int $userId): Builder
     {
-        // Assicurati che il namespace della tua SpesaFactory sia corretto.
-        // Dovrai creare questa Factory in Modules/Spese/Database/Factories/SpesaFactory.php
-        return \Modules\Spese\Database\Factories\SpesaFactory::new();
+        return $query->where('user_id', $userId);
     }
 
-    // Puoi aggiungere qui altri metodi helper o relazioni se necessario.
-    // Esempio: un metodo per formattare l'importo
-    // public function getFormattedAmountAttribute(): string { return number_format($this->amount, 2) . ' â‚¬'; }
-}
+    public function scopeBetweenDates(Builder $query, string $from, string $to): Builder
+    {
+        return $query->whereBetween('date', [$from, $to]);
+    }
 
+    // ===================================================================
+    // Factory
+    // ===================================================================
+
+    protected static function newFactory(): \Modules\Spese\Database\Factories\SpesaFactory
+    {
+        return \Modules\Spese\Database\Factories\SpesaFactory::new();
+    }
+}

--- a/Backend/docs/CHANGELOG_BACKEND.md
+++ b/Backend/docs/CHANGELOG_BACKEND.md
@@ -1,0 +1,6 @@
+# Backend Changelog
+
+## [Unreleased]
+- Added database documentation (ERD, tables overview, renaming plan, constraints, unused tables).
+- Introduced local query scopes and PSR-12 cleanup for Category, Entrata, Spesa models.
+- Added eager loading in EntrateService and SpeseService to mitigate N+1 queries.

--- a/Backend/docs/db/CONSTRAINTS_INDEXES.md
+++ b/Backend/docs/db/CONSTRAINTS_INDEXES.md
@@ -1,0 +1,18 @@
+# Constraints & Index Suggestions
+
+- Add foreign keys where missing:
+  - `entrate.category_id` → `categories.id`
+  - `spese.category_id` → `categories.id`
+  - `recurring_operations.category_id` → `categories.id`
+  - `entrate.user_id`, `spese.user_id`, `recurring_operations.user_id` → `users.id`
+- Add composite indexes:
+  - `entrate` / `spese` / `transactions`: `(user_id, date)` for dashboard queries.
+  - `financial_snapshots`: unique `(user_id, date)` or `(user_id, period_type, period_start_date)` (already present but ensure DB). 
+  - `categories`: `(user_id, name)` unique already; consider index on `type`.
+- Add CHECK constraints:
+  - `transactions.type` in (`entrata`,`spesa`) when unified.
+- Data types:
+  - Monetary fields as `DECIMAL(12,2)`.
+  - Use `NOT NULL` defaults where appropriate (e.g., `description`, `amount`, `date`).
+- Eager loading:
+  - Ensure controllers/services call `with('category')` to avoid N+1.

--- a/Backend/docs/db/ERD_current.mmd
+++ b/Backend/docs/db/ERD_current.mmd
@@ -1,0 +1,55 @@
+erDiagram
+    users {
+        bigint id PK
+        string name
+        string email
+        boolean is_admin
+    }
+    categories {
+        bigint id PK
+        bigint user_id FK
+        string name
+        string type
+    }
+    entrate {
+        bigint id PK
+        bigint user_id FK
+        bigint category_id FK
+        decimal amount
+        date date
+    }
+    spese {
+        bigint id PK
+        bigint user_id FK
+        bigint category_id FK
+        decimal amount
+        date date
+    }
+    recurring_operations {
+        bigint id PK
+        bigint user_id FK
+        bigint category_id FK
+        string type
+        decimal amount
+        date next_occurrence_date
+    }
+    financial_snapshots {
+        bigint id PK
+        bigint user_id FK
+        string period_type
+        decimal balance
+    }
+    audit_logs {
+        bigint id PK
+        bigint user_id FK
+        string action
+    }
+    users ||--o{ categories : owns
+    users ||--o{ entrate : owns
+    users ||--o{ spese : owns
+    users ||--o{ recurring_operations : owns
+    users ||--o{ financial_snapshots : owns
+    users ||--o{ audit_logs : logs
+    categories ||--o{ entrate : categorizes
+    categories ||--o{ spese : categorizes
+    categories ||--o{ recurring_operations : categorizes

--- a/Backend/docs/db/POSSIBLY_UNUSED.md
+++ b/Backend/docs/db/POSSIBLY_UNUSED.md
@@ -1,0 +1,8 @@
+# Possibly Unused Tables
+
+| Table | Reason | Verification |
+|-------|--------|--------------|
+| sessions | Used only when `session.driver=database`. Check `config/session.php` and `.env`. |
+| cache / cache_locks | Required only when `cache.driver=database`. Inspect `config/cache.php`. |
+| audit_logs | Ensure middleware/service writes entries; otherwise table remains empty. |
+| financial_snapshots | Populated by scheduled job; verify task scheduler. |

--- a/Backend/docs/db/RENAMING_PLAN.md
+++ b/Backend/docs/db/RENAMING_PLAN.md
@@ -1,0 +1,54 @@
+# Proposed Renaming Plan
+
+## Unify `entrate` and `spese` → `transactions`
+- **Motivation**: single table simplifies queries and allows `type` field (`entrata`/`spesa`).
+- **Steps**:
+ 1. Create new `transactions` table with `type` enum, copy data from existing tables.
+ 2. Create views `entrate` and `spese` for backward compatibility or update API.
+ 3. Migrate foreign keys from old tables to new `transactions` table.
+
+```php
+// ─────────────────────────────────────────────────────────────────────────────
+// Migrazione di esempio: unificazione 'entrate' + 'spese' → 'transactions' (BOZZA)
+// NOTE: Solo template illustrativo. Non applicare senza piano di migrazione dati.
+// ─────────────────────────────────────────────────────────────────────────────
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('transactions', function (Blueprint $t) {
+            $t->id();
+            $t->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $t->foreignId('category_id')->nullable()->constrained('categories')->nullOnDelete();
+            $t->enum('type', ['entrata','spesa']);
+            $t->decimal('amount', 12, 2);
+            $t->date('date');
+            $t->text('notes')->nullable();
+            $t->timestamps();
+            $t->index(['user_id','date']);
+            $t->index(['category_id','type']);
+        });
+        // TODO: copy data from entrate/spese → transactions
+        // TODO: create VIEW entrate/spese or update API
+    }
+    public function down(): void
+    {
+        Schema::dropIfExists('transactions');
+    }
+};
+```
+
+## `recurring_operations` → `recurring_transactions`
+- **Motivation**: aligns with unified terminology.
+- **Migration sketch**: create `recurring_transactions` with same columns and type field.
+
+## `audit_logs` → `activity_logs`
+- **Motivation**: clearer semantics, matches common naming.
+- **Migration sketch**: rename table then create view `audit_logs` for compatibility.
+
+## Language consistency
+- Consider renaming remaining tables to English equivalents (`entrate`→`incomes` if not unified, `spese`→`expenses`).
+- Ensure column names use snake_case English: e.g., `description`, `amount`, `next_occurrence_date`.
+
+### Risk & Strategy
+- Use blue/green deployment: create new tables, backfill, switch API, drop old tables after validation.
+- Ensure migrations are idempotent and run in maintenance windows.

--- a/Backend/docs/db/TABLES_OVERVIEW.md
+++ b/Backend/docs/db/TABLES_OVERVIEW.md
@@ -1,0 +1,20 @@
+# Tables Overview
+
+| Table | Purpose | Key Columns | FKs | Indexes | Used by |
+|-------|---------|-------------|-----|---------|---------|
+| users | Anagrafica utenti e credenziali | id, username, email, is_admin, deleted_at | - | email unique, username unique | User module |
+| password_reset_tokens | Token reset password | email, token | email→users.email | - | Auth scaffolding |
+| sessions | Sessioni persistite (driver database) | id, user_id, payload | user_id→users.id | last_activity | Laravel session driver |
+| categories | Categorie per entrate/spese | id, user_id, name, type | user_id→users.id | unique(user_id,name) | Category model/service |
+| entrate | Movimenti di entrata | id, user_id, category_id, amount, date | user_id→users.id, category_id→categories.id | index(date), unique(user_id,date,description) | Entrata model/service |
+| spese | Movimenti di spesa | id, user_id, category_id, amount, date | user_id→users.id, category_id→categories.id | index(date), unique(user_id,date,description) | Spesa model/service |
+| recurring_operations | Operazioni ricorrenti | id, user_id, category_id, type, amount, next_occurrence_date | user_id→users.id, category_id→categories.id | index(next_occurrence_date), index(user_id,is_active) | RecurringOperation model/service |
+| financial_snapshots | Snapshot aggregati | id, user_id, period_type, period_start_date | user_id→users.id | unique(user_id,period_type,period_start_date) | FinancialSnapshot model/service |
+| audit_logs | Audit delle azioni | id, user_id, action, auditable_type, auditable_id | user_id→users.id | - | AuditLog model/service |
+| cache | Cache applicativa | key, value, expiration | - | primary key(key) | Cache subsystem |
+| cache_locks | Lock cache | key, owner, expiration | - | primary key(key) | Cache subsystem |
+| jobs | Coda lavori | id, queue, attempts, available_at | - | queue index | Queue system |
+| job_batches | Batch lavori | id, name, total_jobs | - | primary key(id) | Queue batch system |
+| failed_jobs | Job falliti | id, uuid, payload | - | unique(uuid) | Queue system |
+| personal_access_tokens | API tokens | id, tokenable_id, name, token | tokenable_id→users.id | index(token), unique(name,tokenable_id) | Sanctum |
+| migrations | Tracking migrazioni | id, migration, batch | - | - | Framework |


### PR DESCRIPTION
## Summary
- document current DB schema and relationships
- propose naming improvements and constraint/index suggestions
- add query scopes and eager loading to reduce N+1

## Testing
- `./vendor/bin/pint Modules/Entrate/Models/Entrata.php Modules/Spese/Models/Spesa.php Modules/Categories/Models/Category.php Modules/Entrate/Services/EntrateService.php Modules/Spese/Services/SpeseService.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a843c777288324b0acf2ee9e06b939