### PR TITLE
feat: add category suggestion chip

### DIFF
--- a/Frontend-nextjs/.env.example
+++ b/Frontend-nextjs/.env.example
@@ -23,3 +23,9 @@ NEXT_PUBLIC_CDN_URL=http://localhost:3000/images/avatars
 # ⚙️ Feature flags
 # =============================
 NEXT_PUBLIC_BETA=true
+# ─────────────────────────────────────────────────────────────────────────────
+# Sezione: Feature flags
+# ─────────────────────────────────────────────────────────────────────────────
+NEXT_PUBLIC_FEATURE_SUGGEST_CATEGORY=true
+# Assicurati che sia già impostata la base API:
+# NEXT_PUBLIC_API_BASE=http://localhost:8000

--- a/Frontend-nextjs/package-lock.json
+++ b/Frontend-nextjs/package-lock.json
@@ -20,6 +20,7 @@
                 "react": "^18.2.0",
                 "react-chartjs-2": "^5.3.0",
                 "react-dom": "^18.2.0",
+                "react-hook-form": "^7.62.0",
                 "react-icons": "^5.5.0",
                 "react-spinners": "^0.17.0",
                 "sonner": "^2.0.6",
@@ -2059,6 +2060,22 @@
             },
             "peerDependencies": {
                 "react": "^18.3.1"
+            }
+        },
+        "node_modules/react-hook-form": {
+            "version": "7.62.0",
+            "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz",
+            "integrity": "sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/react-hook-form"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17 || ^18 || ^19"
             }
         },
         "node_modules/react-icons": {

--- a/Frontend-nextjs/package.json
+++ b/Frontend-nextjs/package.json
@@ -19,6 +19,7 @@
         "react": "^18.2.0",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^18.2.0",
+        "react-hook-form": "^7.62.0",
         "react-icons": "^5.5.0",
         "react-spinners": "^0.17.0",
         "sonner": "^2.0.6",
@@ -37,4 +38,3 @@
         "typescript": "^5.2.2"
     }
 }
-

--- a/Frontend-nextjs/src/api/mlApi.ts
+++ b/Frontend-nextjs/src/api/mlApi.ts
@@ -1,0 +1,38 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Sezione: ML suggest API client (via backend Laravel protetto Sanctum)
+// Dettagli: POST /api/v1/ml/suggest-category → { category, confidence }
+// ─────────────────────────────────────────────────────────────────────────────
+export type MlSuggestion = { category: string | null; confidence: number };
+
+export async function suggestCategory(description: string, token: string): Promise<MlSuggestion> {
+  // ── guard: input minimo
+  if (!description || description.trim().length < 3) {
+    return { category: null, confidence: 0 };
+  }
+
+  // ── endpoint base
+  const base = process.env.NEXT_PUBLIC_API_BASE;
+  if (!base) return { category: null, confidence: 0 };
+
+  // ── fetch con fallback silenzioso
+  try {
+    const res = await fetch(`${base}/api/v1/ml/suggest-category`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+      },
+      body: JSON.stringify({ description }),
+    });
+    if (!res.ok) return { category: null, confidence: 0 };
+    const data = await res.json() as MlSuggestion;
+    // ── normalizza struttura minima
+    return {
+      category: typeof data?.category === 'string' ? data.category : null,
+      confidence: typeof data?.confidence === 'number' ? data.confidence : 0,
+    };
+  } catch {
+    return { category: null, confidence: 0 };
+  }
+}

--- a/Frontend-nextjs/src/context/AuthContext.ts
+++ b/Frontend-nextjs/src/context/AuthContext.ts
@@ -1,0 +1,10 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Sezione: Hook Auth (token da NextAuth)
+// Dettagli: espone token Bearer per chiamate API
+// ─────────────────────────────────────────────────────────────────────────────
+import { useSession } from 'next-auth/react';
+
+export function useAuth() {
+  const { data } = useSession();
+  return { token: data?.accessToken as string | undefined };
+}

--- a/Frontend-nextjs/src/context/CategoriesContext.ts
+++ b/Frontend-nextjs/src/context/CategoriesContext.ts
@@ -1,0 +1,5 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Sezione: Re-export CategoriesContext
+// Dettagli: espone hook useCategories dal contesto principale
+// ─────────────────────────────────────────────────────────────────────────────
+export { useCategories } from '@/context/contexts/CategoriesContext';

--- a/Frontend-nextjs/src/features/transactions/components/CategorySuggestionChip.tsx
+++ b/Frontend-nextjs/src/features/transactions/components/CategorySuggestionChip.tsx
@@ -1,0 +1,62 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Sezione: UI - Chip suggerimento categoria
+// Dettagli: mostra suggerimento e imposta category_id nel form (RHF) al click
+// ─────────────────────────────────────────────────────────────────────────────
+import React, { useMemo } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { useAuth } from '@/context/AuthContext';
+import { useCategories } from '@/context/CategoriesContext';
+import { useCategorySuggest } from '@/hooks/useCategorySuggest';
+
+type Props = {
+  description: string;
+  threshold?: number; // default 0.6
+};
+
+// ── sinonimi per mapping robusto
+const HINT_MAP: Record<string, string[]> = {
+  cibo: ['cibo', 'alimentari', 'ristorante', 'food', 'pizza', 'pasta'],
+  finanza: ['finanza', 'tasse', 'bollette', 'banca', 'fattura', 'invoice', 'tax'],
+  casa: ['casa', 'affitto', 'utenze', 'home', 'rent'],
+};
+
+// ── util: trova id categoria coerente col suggerimento
+function findCategoryId(hint: string | null, categories: { id:number; name:string }[]) {
+  if (!hint) return null;
+  const keys = HINT_MAP[hint] ?? [hint];
+  const norm = (s:string) => s.toLowerCase();
+  const hit = categories.find(cat => keys.some(k => norm(cat.name).includes(norm(k))));
+  return hit?.id ?? null;
+}
+
+export default function CategorySuggestionChip({ description, threshold = 0.6 }: Props) {
+  const featureOn = process.env.NEXT_PUBLIC_FEATURE_SUGGEST_CATEGORY === 'true';
+  const { token } = useAuth();
+  const { categories } = useCategories();
+  const { setValue } = useFormContext();
+  const { category, confidence } = useCategorySuggest(description, token, featureOn);
+
+  const show = useMemo(() => {
+    return Boolean(category) && typeof confidence === 'number' && confidence >= threshold;
+  }, [category, confidence, threshold]);
+
+  if (!show) return null;
+
+  const onApply = () => {
+    const id = findCategoryId(category, categories);
+    if (id) setValue('category_id', id, { shouldValidate: true, shouldDirty: true });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={onApply}
+      className="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-sm hover:shadow"
+      title="Applica categoria suggerita"
+    >
+      <span>💡 Suggerito: <b>{category}</b></span>
+      <span>({Math.round(confidence * 100)}%)</span>
+      <span className="underline">Applica</span>
+    </button>
+  );
+}

--- a/Frontend-nextjs/src/features/transactions/components/TransactionForm.tsx
+++ b/Frontend-nextjs/src/features/transactions/components/TransactionForm.tsx
@@ -1,0 +1,33 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Sezione: Form transazione con suggeritore categoria ML
+// Dettagli: integra CategorySuggestionChip sotto il campo descrizione
+// ─────────────────────────────────────────────────────────────────────────────
+import React from 'react';
+import { useFormContext } from 'react-hook-form';
+import CategorySuggestionChip from './CategorySuggestionChip';
+
+export default function TransactionForm() {
+  const { register, watch, setValue } = useFormContext();
+
+  return (
+    <form className="space-y-4">
+      <div>
+        <label htmlFor="description" className="block text-sm font-medium mb-1">Descrizione</label>
+        <input
+          id="description"
+          {...register('description')}
+          className="w-full rounded border px-3 py-2"
+        />
+        {/* ─────────────────────────────────────────────────────────────────────────────
+            Sezione: Chip suggerimento categoria (visibile se utile)
+            ───────────────────────────────────────────────────────────────────────────── */}
+        <CategorySuggestionChip description={watch('description') as string} />
+      </div>
+      <div>
+        <label htmlFor="category" className="block text-sm font-medium mb-1">Categoria</label>
+        <input id="category" type="number" {...register('category_id')} className="w-full rounded border px-3 py-2" />
+      </div>
+      <button type="submit" className="px-4 py-2 bg-primary text-white rounded">Salva</button>
+    </form>
+  );
+}

--- a/Frontend-nextjs/src/hooks/useCategorySuggest.ts
+++ b/Frontend-nextjs/src/hooks/useCategorySuggest.ts
@@ -1,0 +1,25 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Sezione: Hook di suggerimento ML con debounce
+// Dettagli: chiama l’API dopo 300ms di pausa nella digitazione
+// ─────────────────────────────────────────────────────────────────────────────
+import { useEffect, useRef, useState } from 'react';
+import { suggestCategory, MlSuggestion } from '@/api/mlApi';
+
+export function useCategorySuggest(description: string, token?: string, enabled = true) {
+  const [data, setData] = useState<MlSuggestion>({ category: null, confidence: 0 });
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!enabled || !token) { setData({ category: null, confidence: 0 }); return; }
+    if (timer.current) clearTimeout(timer.current);
+
+    timer.current = setTimeout(async () => {
+      try { setData(await suggestCategory(description, token)); }
+      catch { setData({ category: null, confidence: 0 }); }
+    }, 300);
+
+    return () => { if (timer.current) clearTimeout(timer.current); };
+  }, [description, token, enabled]);
+
+  return data; // { category, confidence }
+}

--- a/Frontend-nextjs/tsconfig.json
+++ b/Frontend-nextjs/tsconfig.json
@@ -17,7 +17,7 @@
         "plugins": [{ "name": "next" }],
         "baseUrl": ".",
         "paths": {
-            "@/*": ["./*"]
+            "@/*": ["./src/*", "./*"]
         }
     },
     "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## Summary
- integrate ML category suggestion API client
- add useCategorySuggest hook with debounce
- show CategorySuggestionChip in transaction form

## Testing
- `npm run build`
- `npm run dev`
- `npm run lint` *(fails: Missing script "lint")*
- `npm run typecheck` *(fails: Missing script "typecheck")*

------
https://chatgpt.com/codex/tasks/task_e_68a87df1a8948324aa497d7d59b8b59f