### PR TITLE
chore: add api helpers and smoke tests

### DIFF
--- a/Frontend-nextjs/.eslintrc.json
+++ b/Frontend-nextjs/.eslintrc.json
@@ -1,3 +1,7 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": "next/core-web-vitals",
+  "plugins": ["no-global-context"],
+  "rules": {
+    "no-global-context/no-global-context": "error"
+  }
 }

--- a/Frontend-nextjs/eslint-plugin-no-global-context/index.js
+++ b/Frontend-nextjs/eslint-plugin-no-global-context/index.js
@@ -1,0 +1,17 @@
+module.exports = {
+  rules: {
+    'no-global-context': {
+      meta: { type: 'problem' },
+      create(context) {
+        return {
+          ImportDeclaration(node) {
+            const value = node.source.value;
+            if (typeof value === 'string' && (value.includes('GlobalContextProvider') || value.includes('context/contexts'))) {
+              context.report({ node, message: 'Global context aggregators are forbidden' });
+            }
+          }
+        };
+      }
+    }
+  }
+};

--- a/Frontend-nextjs/package-lock.json
+++ b/Frontend-nextjs/package-lock.json
@@ -24,7 +24,8 @@
                 "react-icons": "^5.5.0",
                 "react-spinners": "^0.17.0",
                 "sonner": "^2.0.6",
-                "usehooks-ts": "^3.1.1"
+                "usehooks-ts": "^3.1.1",
+                "zod": "^3.23.8"
             },
             "devDependencies": {
                 "@tailwindcss/aspect-ratio": "^0.4.2",
@@ -36,10 +37,14 @@
                 "autoprefixer": "^10.4.21",
                 "eslint": "8.57.1",
                 "eslint-config-next": "15.5.0",
+                "eslint-plugin-no-global-context": "file:eslint-plugin-no-global-context",
                 "postcss": "^8.5.6",
                 "tailwindcss": "^3.4.17",
                 "typescript": "^5.2.2"
             }
+        },
+        "eslint-plugin-no-global-context": {
+            "dev": true
         },
         "node_modules/@alloc/quick-lru": {
             "version": "5.2.0",
@@ -2903,6 +2908,10 @@
             "engines": {
                 "node": "*"
             }
+        },
+        "node_modules/eslint-plugin-no-global-context": {
+            "resolved": "eslint-plugin-no-global-context",
+            "link": true
         },
         "node_modules/eslint-plugin-react": {
             "version": "7.37.5",
@@ -6934,6 +6943,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/zod": {
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
             }
         }
     }

--- a/Frontend-nextjs/package.json
+++ b/Frontend-nextjs/package.json
@@ -6,7 +6,8 @@
         "build": "next build",
         "start": "next start",
         "typecheck": "tsc -p tsconfig.json --noEmit",
-        "lint": "next lint"
+        "lint": "next lint",
+        "check:routes": "node scripts/check-routes.ts"
     },
     "dependencies": {
         "@headlessui/react": "^2.2.4",
@@ -25,7 +26,8 @@
         "react-icons": "^5.5.0",
         "react-spinners": "^0.17.0",
         "sonner": "^2.0.6",
-        "usehooks-ts": "^3.1.1"
+        "usehooks-ts": "^3.1.1",
+        "zod": "^3.23.8"
     },
     "devDependencies": {
         "@tailwindcss/aspect-ratio": "^0.4.2",
@@ -39,6 +41,7 @@
         "eslint-config-next": "15.5.0",
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.17",
-        "typescript": "^5.2.2"
+        "typescript": "^5.2.2",
+        "eslint-plugin-no-global-context": "file:eslint-plugin-no-global-context"
     }
 }

--- a/Frontend-nextjs/scripts/check-routes.ts
+++ b/Frontend-nextjs/scripts/check-routes.ts
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+const { API, url } = await import("../src/lib/api/endpoints.ts");
+const keys = Object.keys(API).filter((k) => k !== "base");
+for (const key of keys) {
+  const target = url(key);
+  try {
+    const res = await fetch(target, { method: "HEAD" });
+    const ok = res.ok || res.status === 401;
+    console.log(`${API[key]} - ${ok ? "OK" : `ERR ${res.status}`}`);
+  } catch (err) {
+    console.log(`${API[key]} - ERR ${(err).message}`);
+  }
+}

--- a/Frontend-nextjs/scripts/ml_smoke_test.ps1
+++ b/Frontend-nextjs/scripts/ml_smoke_test.ps1
@@ -1,0 +1,77 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Sezione: Utils stampa
+# Dettagli: funzioni helper colorate
+# ─────────────────────────────────────────────────────────────────────────────
+function Write-Ok($msg){ Write-Host "✅ $msg" -ForegroundColor Green }
+function Write-Warn($msg){ Write-Host "⚠️ $msg" -ForegroundColor Yellow }
+function Write-Err($msg){ Write-Host "❌ $msg" -ForegroundColor Red }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Sezione: HTTP helper
+# Dettagli: invoca endpoint JSON
+# ─────────────────────────────────────────────────────────────────────────────
+function Invoke-Json($method,$url,$headers,$body=$null){
+    try{
+        $params=@{Method=$method;Uri=$url;Headers=$headers;ContentType="application/json";TimeoutSec=5}
+        if($body){$params.Body=($body|ConvertTo-Json)}
+        return Invoke-RestMethod @params
+    }catch{throw}
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Sezione: Test ML
+# Dettagli: health + prediction
+# ─────────────────────────────────────────────────────────────────────────────
+function Test-Health($mlBase){
+    try{
+        $res=Invoke-Json 'GET' "$mlBase/health" @{}
+        if($res.status -eq 'ok'){Write-Ok "ML health";return $true}
+        Write-Err "ML health payload";return $false
+    }catch{Write-Err "ML health $_";return $false}
+}
+
+function Test-PredictPizza($mlBase){
+    try{
+        $res=Invoke-Json 'POST' "$mlBase/predict-category" @{} @{description="Pizza Margherita"}
+        if($res.category -eq 'cibo' -and [double]$res.confidence -ge 0.9){Write-Ok "ML predict";return $true}
+        Write-Err "ML predict mismatch";return $false
+    }catch{Write-Err "ML predict $_";return $false}
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Sezione: Test Laravel
+# Dettagli: suggest category via Sanctum
+# ─────────────────────────────────────────────────────────────────────────────
+function Test-LaravelSuggest($apiBase,$token){
+    try{
+        $h=@{Authorization="Bearer $token"}
+        $res=Invoke-Json 'POST' "$apiBase/api/v1/ml/suggest-category" $h @{description="Affitto agosto"}
+        if($res.category -eq 'casa' -and [double]$res.confidence -ge 0.7){Write-Ok "Laravel suggest";return $true}
+        Write-Err "Laravel suggest mismatch";return $false
+    }catch{Write-Err "Laravel suggest $_";return $false}
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Sezione: Main
+# Dettagli: orchestrazione smoke test
+# ─────────────────────────────────────────────────────────────────────────────
+param(
+    [string]$MlBase="http://127.0.0.1:7001",
+    [string]$ApiBase="http://127.0.0.1:8000",
+    [string]$Token=""
+)
+
+Write-Host "ML Base: $MlBase"
+Write-Host "API Base: $ApiBase"
+if($Token){Write-Host "Token: ****"}else{Write-Warn "Token assente"}
+
+$all=$true
+$all=(Test-Health $MlBase) -and $all
+$all=(Test-PredictPizza $MlBase) -and $all
+if($Token){$all=(Test-LaravelSuggest $ApiBase $Token) -and $all}else{Write-Warn "Laravel skipped"}
+
+if($all){Write-Ok "Smoke test completed";exit 0}else{Write-Err "Smoke test failed";exit 1}
+
+# Esempi:
+# powershell -ExecutionPolicy Bypass -File .\scripts\ml_smoke_test.ps1
+# powershell -ExecutionPolicy Bypass -File .\scripts\ml_smoke_test.ps1 -MlBase http://localhost:7001 -ApiBase http://localhost:8000 -Token "<SANCTUM_TOKEN>"

--- a/Frontend-nextjs/src/lib/api/adapters/recurringApi.ts
+++ b/Frontend-nextjs/src/lib/api/adapters/recurringApi.ts
@@ -1,0 +1,13 @@
+import { url } from "../endpoints";
+import { api } from "../http";
+import { RecurringItemSchema, RecurringListSchema } from "../../../schema/recurring";
+
+export async function listRecurring() {
+  const data = await api<unknown>(url("recurring"));
+  return RecurringListSchema.parse(data);
+}
+
+export async function getRecurring(id: number) {
+  const data = await api<unknown>(url("recurring", id));
+  return RecurringItemSchema.parse(data);
+}

--- a/Frontend-nextjs/src/lib/api/endpoints.ts
+++ b/Frontend-nextjs/src/lib/api/endpoints.ts
@@ -1,0 +1,11 @@
+export const API = {
+  base: process.env.NEXT_PUBLIC_API_BASE_URL!,
+  me: "/api/v1/me",
+  entrate: "/api/v1/entrate",
+  spese: "/api/v1/spese",
+  categories: "/api/v1/categories",
+  recurring: "/api/v1/recurring-operations",
+} as const;
+export type EndpointKey = keyof typeof API;
+export const url = (k: EndpointKey, id?: string | number) =>
+  id != null ? `${API.base}${API[k]}/${id}` : `${API.base}${API[k]}`;

--- a/Frontend-nextjs/src/lib/api/http.ts
+++ b/Frontend-nextjs/src/lib/api/http.ts
@@ -1,0 +1,20 @@
+export async function api<T>(input: string, init: RequestInit = {}): Promise<T> {
+  const token = typeof window !== "undefined" ? localStorage.getItem("token") : undefined;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    ...(init.headers as Record<string, string>),
+  };
+  const res = await fetch(input, { ...init, headers });
+  if (!res.ok) {
+    let msg = "Request error";
+    if (res.status === 401) msg = "Unauthorized";
+    else if (res.status === 404) msg = "Not found";
+    else if (res.status === 422) msg = "Unprocessable entity";
+    throw new Error(msg);
+  }
+  if (res.status === 204) {
+    return undefined as T;
+  }
+  return (await res.json()) as T;
+}

--- a/Frontend-nextjs/src/schema/recurring.ts
+++ b/Frontend-nextjs/src/schema/recurring.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+export const RecurringItemSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  amount: z.number(),
+  frequency: z.string(),
+  next_run_at: z.string(),
+  category_id: z.number(),
+  notes: z.string().optional().nullable(),
+  type: z.enum(["entrata", "spesa"]),
+  active: z.boolean(),
+  interval: z.number(),
+});
+
+export const RecurringListSchema = z.array(RecurringItemSchema);
+
+export type RecurringItem = z.infer<typeof RecurringItemSchema>;


### PR DESCRIPTION
## Summary
- centralize API endpoints and HTTP helper
- add recurring adapter with Zod validation
- provide route QA and ML/Laravel smoke test scripts
- enforce lint rule against global context aggregators

## Testing
- `npm run lint` (fails: Global context aggregators are forbidden)
- `npm run typecheck` (fails: missing modules and TS config for scripts)
- `npm run check:routes` (fails: Failed to parse URL from undefined/api/v1/me)


------
https://chatgpt.com/codex/tasks/task_e_68a9afbee224832497312371e8bbde57