### PR TITLE
Constrain category routes to numeric IDs

### DIFF
--- a/Backend/Modules/Categories/Routes/api.php
+++ b/Backend/Modules/Categories/Routes/api.php
@@ -10,12 +10,15 @@ Route::middleware(['auth:sanctum'])
         Route::get('categories', [CategoriesController::class, 'indexApi'])
             ->name('categories.index');
         Route::get('categories/{category}', [CategoriesController::class, 'showApi'])
+            ->whereNumber('category')
             ->name('categories.show');
         Route::post('categories', [CategoriesController::class, 'storeApi'])
             ->name('categories.store');
         Route::put('categories/{category}', [CategoriesController::class, 'updateApi'])
+            ->whereNumber('category')
             ->name('categories.update');
         Route::delete('categories/{category}', [CategoriesController::class, 'destroyApi'])
+            ->whereNumber('category')
             ->name('categories.destroy');
     });
 


### PR DESCRIPTION
## Summary
- ensure category route parameters are numeric by chaining `whereNumber('category')`

## Testing
- `php artisan route:list | head -n 20`
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68a9b5a448e08324baa1e1dac430fe9d