### PR TITLE
refactor: simplify category suggestion response

### DIFF
--- a/Backend/Modules/Categories/Http/Controllers/CategorySuggestionApiController.php
+++ b/Backend/Modules/Categories/Http/Controllers/CategorySuggestionApiController.php
@@ -27,9 +27,8 @@ class CategorySuggestionApiController extends Controller
 
         $suggestion = $this->client->suggest($data['description']);
 
-        return response()->json([
-            'description' => $data['description'],
-            'suggestion' => $suggestion,
-        ]);
+        // Return the suggestion payload directly so the endpoint responds with
+        // { category: ..., confidence: ... }
+        return response()->json($suggestion);
     }
 }

--- a/Backend/Modules/Categories/tests/Feature/CategorySuggestionEndpointTest.php
+++ b/Backend/Modules/Categories/tests/Feature/CategorySuggestionEndpointTest.php
@@ -32,9 +32,11 @@ class CategorySuggestionEndpointTest extends TestCase
 
         $this->postJson('/api/v1/ml/suggest-category', $payload)
             ->assertStatus(200)
-            ->assertJsonStructure([
-                'description',
-                'suggestion' => ['category', 'confidence'],
-            ]);
+            ->assertJson([
+                'category' => 'cibo',
+                'confidence' => 0.9,
+            ])
+            ->assertJsonMissingPath('description')
+            ->assertJsonStructure(['category', 'confidence']);
     }
 }

--- a/Frontend-nextjs/src/api/mlApi.ts
+++ b/Frontend-nextjs/src/api/mlApi.ts
@@ -26,11 +26,11 @@ export async function suggestCategory(description: string, token: string): Promi
       body: JSON.stringify({ description }),
     });
     if (!res.ok) return { category: null, confidence: 0 };
-    const data = await res.json() as MlSuggestion;
+    const data = await res.json() as { category?: unknown; confidence?: unknown };
     // ── normalizza struttura minima
     return {
-      category: typeof data?.category === 'string' ? data.category : null,
-      confidence: typeof data?.confidence === 'number' ? data.confidence : 0,
+      category: typeof data.category === 'string' ? data.category : null,
+      confidence: typeof data.confidence === 'number' ? data.confidence : 0,
     };
   } catch {
     return { category: null, confidence: 0 };


### PR DESCRIPTION
## Summary
- return `{category, confidence}` directly from CategorySuggestionApiController
- align mlApi suggestion client with new response shape
- update feature test for new ML suggestion payload format

## Testing
- `./vendor/bin/phpunit Modules/Categories/tests/Feature/CategorySuggestionEndpointTest.php`
- `npm --prefix Frontend-nextjs run lint -- src/api/mlApi.ts` *(fails: Couldn't find any `pages` or `app` directory)*
- `npm --prefix Frontend-nextjs run typecheck` *(fails: Cannot find module './card/CardTotaliAnnui', and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b671b77c8324b84ee48309a29695