### PR TITLE
refactor: centralize API endpoints

### DIFF
--- a/Frontend-nextjs/.env.example
+++ b/Frontend-nextjs/.env.example
@@ -9,10 +9,10 @@ NEXTAUTH_URL=http://localhost:3000
 # =============================
 
 # Backend locale (sviluppo)
-NEXT_PUBLIC_API_URL=http://localhost:8484/api
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8484
 
 # Backend cloud/beta (commenta sopra e decommenta sotto se vuoi usarlo)
-# NEXT_PUBLIC_API_URL=https://synapsy-backend.onrender.com/api
+# NEXT_PUBLIC_API_BASE_URL=https://synapsy-backend.onrender.com
 
 # =============================
 # 🌐 CDN URL (immagini, avatar, ecc.)
@@ -28,4 +28,4 @@ NEXT_PUBLIC_BETA=true
 # ─────────────────────────────────────────────────────────────────────────────
 NEXT_PUBLIC_FEATURE_SUGGEST_CATEGORY=true
 # Assicurati che sia già impostata la base API:
-# NEXT_PUBLIC_API_BASE=http://localhost:8000
+# NEXT_PUBLIC_API_BASE_URL=http://localhost:8484

--- a/Frontend-nextjs/docs/DEPLOY.md
+++ b/Frontend-nextjs/docs/DEPLOY.md
@@ -6,14 +6,14 @@ Pubblicazione del frontend su Vercel o piattaforme simili.
 
 ## Vercel
 1. Importa il progetto da GitHub selezionando la cartella `Frontend-nextjs`
-2. Imposta le variabili d'ambiente (`NEXT_PUBLIC_API_URL`)
+2. Imposta le variabili d'ambiente (`NEXT_PUBLIC_API_BASE_URL`)
 3. Comando di build: `npm run build`
 4. Comando di start: automatico
 
 ## Variabili principali
 | Nome | Descrizione |
 |------|-------------|
-| `NEXT_PUBLIC_API_URL` | URL delle API Laravel |
+| `NEXT_PUBLIC_API_BASE_URL` | URL delle API Laravel |
 | `NEXT_PUBLIC_BETA` | abilita il login demo |
 
 ## Errori comuni

--- a/Frontend-nextjs/hooks/useAvatars.ts
+++ b/Frontend-nextjs/hooks/useAvatars.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { url } from "@/lib/api/endpoints";
 
 export type AvatarOption = {
     id: number;
@@ -13,14 +14,7 @@ export function useAvatars() {
     const [loading, setLoading] = useState(true);
 
     useEffect(() => {
-        const apiUrl = process.env.NEXT_PUBLIC_API_URL;
-        if (!apiUrl) {
-            console.error("NEXT_PUBLIC_API_URL non definita");
-            setLoading(false);
-            return;
-        }
-
-        fetch(`${apiUrl}/v1/avatars`)
+        fetch(url("avatars"))
             .then((res) => {
                 if (!res.ok) throw new Error(`Errore HTTP: ${res.status}`);
                 return res.json();

--- a/Frontend-nextjs/lib/api/categoriesApi.ts
+++ b/Frontend-nextjs/lib/api/categoriesApi.ts
@@ -4,13 +4,13 @@
 // ╚══════════════════════════════════════════════════════╝
 
 import { Category, CategoryBase } from "@/types/models/category";
-const API_URL = process.env.NEXT_PUBLIC_API_URL;
+import { url } from "@/lib/api/endpoints";
 
 // ==============================
 // Fetch: Lista categorie
 // ==============================
 export async function getAllCategories(token: string): Promise<Category[]> {
-    const res = await fetch(`${API_URL}/v1/categories`, {
+    const res = await fetch(url("categories"), {
         headers: {
             "Content-Type": "application/json",
             Authorization: `Bearer ${token}`,
@@ -26,7 +26,7 @@ export async function getAllCategories(token: string): Promise<Category[]> {
 // Create: Nuova categoria
 // ==============================
 export async function createCategory(token: string, payload: CategoryBase): Promise<Category> {
-    const res = await fetch(`${API_URL}/v1/categories`, {
+    const res = await fetch(url("categories"), {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
@@ -42,7 +42,7 @@ export async function createCategory(token: string, payload: CategoryBase): Prom
 // Update: Modifica categoria
 // ==============================
 export async function updateCategory(token: string, id: number, data: CategoryBase): Promise<Category> {
-    const res = await fetch(`${API_URL}/v1/categories/${id}`, {
+    const res = await fetch(url("categories", id), {
         method: "PUT",
         headers: {
             "Content-Type": "application/json",
@@ -58,7 +58,7 @@ export async function updateCategory(token: string, id: number, data: CategoryBa
 // Delete: Elimina categoria
 // ==============================
 export async function deleteCategory(token: string, categoryId: number): Promise<boolean> {
-    const res = await fetch(`${API_URL}/v1/categories/${categoryId}`, {
+    const res = await fetch(url("categories", categoryId), {
         method: "DELETE",
         headers: {
             Authorization: `Bearer ${token}`,
@@ -72,7 +72,7 @@ export async function deleteCategory(token: string, categoryId: number): Promise
 // Move: Sposta tutte le ENTRATE a un'altra categoria
 // ==============================
 export async function moveEntrateToCategory(token: string, oldCategoryId: number, newCategoryId: number) {
-    const res = await fetch(`${API_URL}/v1/entrate/move-category`, {
+    const res = await fetch(`${url("entrate")}/move-category`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
         body: JSON.stringify({ oldCategoryId, newCategoryId }),
@@ -85,7 +85,7 @@ export async function moveEntrateToCategory(token: string, oldCategoryId: number
 // Move: Sposta tutte le SPESE a un'altra categoria
 // ==============================
 export async function moveSpeseToCategory(token: string, oldCategoryId: number, newCategoryId: number) {
-    const res = await fetch(`${API_URL}/v1/spese/move-category`, {
+    const res = await fetch(`${url("spese")}/move-category`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
         body: JSON.stringify({ oldCategoryId, newCategoryId }),
@@ -98,7 +98,7 @@ export async function moveSpeseToCategory(token: string, oldCategoryId: number, 
 // Move: Sposta tutte le RICORRENZE a un'altra categoria
 // ==============================
 export async function moveRecurringToCategory(token: string, oldCategoryId: number, newCategoryId: number) {
-    const res = await fetch(`${API_URL}/v1/recurring-operations/move-category`, {
+    const res = await fetch(`${url("recurring")}/move-category`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
         body: JSON.stringify({ oldCategoryId, newCategoryId }),

--- a/Frontend-nextjs/lib/api/ricorrenzeApi.ts
+++ b/Frontend-nextjs/lib/api/ricorrenzeApi.ts
@@ -3,11 +3,7 @@
 // ╚═══════════════════════════════════════════════════════════╝
 
 import { Ricorrenza, RicorrenzaBase } from "@/types/models/ricorrenza";
-
-// ==============================
-// URL BASE (usa variabile ENV)
-// ==============================
-const API_URL = process.env.NEXT_PUBLIC_API_URL;
+import { url } from "@/lib/api/endpoints";
 
 // ==============================
 // Funzione di mapping frequenza IT → EN per backend
@@ -37,7 +33,7 @@ function frequencyToBackend(freq: string): string {
 // Fetch: Lista ricorrenze
 // ==============================
 export async function fetchRicorrenze(token: string): Promise<Ricorrenza[]> {
-    const res = await fetch(`${API_URL}/v1/recurring-operations`, {
+    const res = await fetch(url("recurring"), {
         headers: {
             "Content-Type": "application/json",
             Authorization: `Bearer ${token}`,
@@ -73,7 +69,7 @@ export async function createRicorrenza(token: string, data: RicorrenzaBase): Pro
         type: data.type, // opzionale, se richiesto
     };
 
-    const res = await fetch(`${API_URL}/v1/recurring-operations`, {
+    const res = await fetch(url("recurring"), {
         method: "POST",
         headers: {
             Authorization: `Bearer ${token}`,
@@ -108,7 +104,7 @@ export async function updateRicorrenza(token: string, id: number, data: Ricorren
         type: data.type,
     };
 
-    const res = await fetch(`${API_URL}/v1/recurring-operations/${id}`, {
+    const res = await fetch(url("recurring", id), {
         method: "PUT",
         headers: {
             "Content-Type": "application/json",
@@ -125,7 +121,7 @@ export async function updateRicorrenza(token: string, id: number, data: Ricorren
 // Delete: Elimina ricorrenza
 // ==============================
 export async function deleteRicorrenza(token: string, ricorrenza: Ricorrenza): Promise<void> {
-    const res = await fetch(`${API_URL}/v1/recurring-operations/${ricorrenza.id}`, {
+    const res = await fetch(url("recurring", ricorrenza.id), {
         method: "DELETE",
         headers: {
             Authorization: `Bearer ${token}`,

--- a/Frontend-nextjs/lib/api/userApi.ts
+++ b/Frontend-nextjs/lib/api/userApi.ts
@@ -3,14 +3,13 @@
 // ╚═════════════════════════════════════════════════════════╝
 
 import type { UserType } from "@/types/models/user";
-
-const API_URL = process.env.NEXT_PUBLIC_API_URL;
+import { url } from "@/lib/api/endpoints";
 
 // ==============================
 // GET profilo corrente
 // ==============================
 export async function fetchUserProfile(token: string): Promise<UserType> {
-    const res = await fetch(`${API_URL}/v1/profile`, {
+    const res = await fetch(url("profile"), {
         headers: {
             "Content-Type": "application/json",
             Authorization: `Bearer ${token}`,
@@ -29,7 +28,7 @@ export async function updateUserProfile(
     token: string,
     payload: Partial<UserType>
 ): Promise<UserType> {
-    const res = await fetch(`${API_URL}/v1/profile`, {
+    const res = await fetch(url("profile"), {
         method: "PUT",
         headers: {
             "Content-Type": "application/json",
@@ -47,7 +46,7 @@ export async function updateUserProfile(
 // DELETE pending email
 // ==============================
 export async function cancelPendingEmail(token: string): Promise<UserType> {
-    const res = await fetch(`${API_URL}/v1/profile/pending-email`, {
+    const res = await fetch(`${url("profile")}/pending-email`, {
         method: "DELETE",
         headers: {
             "Content-Type": "application/json",
@@ -64,7 +63,7 @@ export async function cancelPendingEmail(token: string): Promise<UserType> {
 // RESEND pending email link
 // ==============================
 export async function resendPendingEmail(token: string): Promise<void> {
-    const res = await fetch(`${API_URL}/v1/profile/pending-email/resend`, {
+    const res = await fetch(`${url("profile")}/pending-email/resend`, {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
@@ -80,7 +79,7 @@ export async function resendPendingEmail(token: string): Promise<void> {
 // DELETE profilo (soft delete)
 // ==============================
 export async function deleteUserProfile(token: string, password: string): Promise<void> {
-    const res = await fetch(`${API_URL}/v1/profile`, {
+    const res = await fetch(url("profile"), {
         method: "DELETE",
         headers: {
             "Content-Type": "application/json",

--- a/Frontend-nextjs/lib/auth/authOptions.ts
+++ b/Frontend-nextjs/lib/auth/authOptions.ts
@@ -1,10 +1,6 @@
 import Credentials from "next-auth/providers/credentials";
 import { type NextAuthOptions } from "next-auth";
-
-if (!process.env.NEXT_PUBLIC_API_URL) {
-  throw new Error("NEXT_PUBLIC_API_URL non definita");
-}
-const API = process.env.NEXT_PUBLIC_API_URL;
+import { url } from "@/lib/api/endpoints";
 
 export const authOptions: NextAuthOptions = {
   providers: [
@@ -15,7 +11,7 @@ export const authOptions: NextAuthOptions = {
         password: { type: "password" },
       },
       async authorize(credentials) {
-        const res = await fetch(`${API}/v1/login`, {
+        const res = await fetch(url("login"), {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(credentials),
@@ -37,7 +33,7 @@ export const authOptions: NextAuthOptions = {
       credentials: { token: { type: "text" } },
       async authorize(credentials) {
         if (!credentials?.token) return null;
-        const res = await fetch(`${API}/v1/me`, {
+        const res = await fetch(url("me"), {
           headers: { Authorization: `Bearer ${credentials.token}` },
         });
         if (!res.ok) return null;

--- a/Frontend-nextjs/lib/auth/handleForgotPassword.ts
+++ b/Frontend-nextjs/lib/auth/handleForgotPassword.ts
@@ -1,9 +1,8 @@
 // lib/auth/handleForgotPassword.ts
-const API_URL = process.env.NEXT_PUBLIC_API_URL;
+import { url } from "@/lib/api/endpoints";
 
 export async function handleForgotPassword(email: string): Promise<{success:boolean; message:string}> {
-    if (!API_URL) throw new Error('NEXT_PUBLIC_API_URL not defined');
-    const res = await fetch(`${API_URL}/v1/forgot-password`, {
+    const res = await fetch(url("forgotPassword"), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
         body: JSON.stringify({ email }),

--- a/Frontend-nextjs/lib/auth/handleRegister.ts
+++ b/Frontend-nextjs/lib/auth/handleRegister.ts
@@ -1,6 +1,6 @@
 // lib/auth/handleRegister.ts
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL;
+import { url } from "@/lib/api/endpoints";
 
 export interface RegisterPayload {
     name: string;
@@ -13,8 +13,7 @@ export interface RegisterPayload {
 }
 
 export async function handleRegister(payload: RegisterPayload): Promise<{success:boolean; message:string}> {
-    if (!API_URL) throw new Error('NEXT_PUBLIC_API_URL not defined');
-    const res = await fetch(`${API_URL}/v1/register`, {
+    const res = await fetch(url("register"), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
         body: JSON.stringify(payload),

--- a/Frontend-nextjs/lib/auth/handleResetPassword.ts
+++ b/Frontend-nextjs/lib/auth/handleResetPassword.ts
@@ -1,4 +1,4 @@
-const API_URL = process.env.NEXT_PUBLIC_API_URL;
+import { url } from "@/lib/api/endpoints";
 
 export interface ResetPayload {
   email: string;
@@ -8,8 +8,7 @@ export interface ResetPayload {
 }
 
 export async function handleResetPassword(payload: ResetPayload): Promise<{success:boolean; message:string}> {
-  if (!API_URL) throw new Error('NEXT_PUBLIC_API_URL not defined');
-  const res = await fetch(`${API_URL}/v1/reset-password`, {
+  const res = await fetch(url("resetPassword"), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
     body: JSON.stringify(payload),

--- a/Frontend-nextjs/src/api/mlApi.ts
+++ b/Frontend-nextjs/src/api/mlApi.ts
@@ -2,6 +2,8 @@
 // Sezione: ML suggest API client (via backend Laravel protetto Sanctum)
 // Dettagli: POST /api/v1/ml/suggest-category → { category, confidence }
 // ─────────────────────────────────────────────────────────────────────────────
+import { url } from "@/lib/api/endpoints";
+
 export type MlSuggestion = { category: string | null; confidence: number };
 
 export async function suggestCategory(description: string, token: string): Promise<MlSuggestion> {
@@ -10,13 +12,9 @@ export async function suggestCategory(description: string, token: string): Promi
     return { category: null, confidence: 0 };
   }
 
-  // ── endpoint base
-  const base = process.env.NEXT_PUBLIC_API_BASE;
-  if (!base) return { category: null, confidence: 0 };
-
   // ── fetch con fallback silenzioso
   try {
-    const res = await fetch(`${base}/api/v1/ml/suggest-category`, {
+    const res = await fetch(url("mlSuggestCategory"), {
       method: 'POST',
       headers: {
         'Authorization': `Bearer ${token}`,

--- a/Frontend-nextjs/src/lib/api/endpoints.ts
+++ b/Frontend-nextjs/src/lib/api/endpoints.ts
@@ -1,10 +1,18 @@
 export const API = {
   base: process.env.NEXT_PUBLIC_API_BASE_URL!,
+  login: "/api/v1/login",
+  register: "/api/v1/register",
+  forgotPassword: "/api/v1/forgot-password",
+  resetPassword: "/api/v1/reset-password",
   me: "/api/v1/me",
+  profile: "/api/v1/profile",
+  avatars: "/api/v1/avatars",
+  financialOverview: "/api/v1/financialoverview",
   entrate: "/api/v1/entrate",
   spese: "/api/v1/spese",
   categories: "/api/v1/categories",
   recurring: "/api/v1/recurring-operations",
+  mlSuggestCategory: "/api/v1/ml/suggest-category",
 } as const;
 export type EndpointKey = keyof typeof API;
 export const url = (k: EndpointKey, id?: string | number) =>


### PR DESCRIPTION
## Summary
- unify frontend API base variable to `NEXT_PUBLIC_API_BASE_URL`
- centralize endpoint paths and reuse `url()` in API clients
- update docs for new environment variable

## Testing
- `npm run lint` *(fails: no-global-context/no-global-context errors)*
- `npm run typecheck` *(fails: missing modules and top-level await errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b77773788324bef3ccf28cbf59b0