### PR TITLE
Rename category suggestion flag

### DIFF
--- a/Frontend-nextjs/.env.example
+++ b/Frontend-nextjs/.env.example
@@ -26,6 +26,6 @@ NEXT_PUBLIC_BETA=true
 # ─────────────────────────────────────────────────────────────────────────────
 # Sezione: Feature flags
 # ─────────────────────────────────────────────────────────────────────────────
-NEXT_PUBLIC_FEATURE_SUGGEST_CATEGORY=true
+NEXT_PUBLIC_FEATURE_ML_SUGGEST=true
 # Assicurati che sia già impostata la base API:
 # NEXT_PUBLIC_API_BASE=http://localhost:8000

--- a/Frontend-nextjs/docs/README.md
+++ b/Frontend-nextjs/docs/README.md
@@ -36,6 +36,9 @@ npm run dev
 ```
 L'app è disponibile su [http://localhost:3000](http://localhost:3000)
 
+## ⚙️ Feature flags
+- `NEXT_PUBLIC_FEATURE_ML_SUGGEST`: abilita il suggerimento automatico della categoria tramite modello ML.
+
 ---
 
 ## 📚 Documentazione

--- a/Frontend-nextjs/src/features/transactions/components/CategorySuggestionChip.tsx
+++ b/Frontend-nextjs/src/features/transactions/components/CategorySuggestionChip.tsx
@@ -30,7 +30,7 @@ function findCategoryId(hint: string | null, categories: { id:number; name:strin
 }
 
 export default function CategorySuggestionChip({ description, threshold = 0.6 }: Props) {
-  const featureOn = process.env.NEXT_PUBLIC_FEATURE_SUGGEST_CATEGORY === 'true';
+  const featureOn = process.env.NEXT_PUBLIC_FEATURE_ML_SUGGEST === 'true';
   const { token } = useAuth();
   const { categories } = useCategories();
   const { setValue } = useFormContext();


### PR DESCRIPTION
## Summary
- rename `NEXT_PUBLIC_FEATURE_SUGGEST_CATEGORY` to `NEXT_PUBLIC_FEATURE_ML_SUGGEST`
- update category suggestion component to use new flag
- document the new flag in frontend docs

## Testing
- `npm run lint` (fails: Global context aggregators are forbidden)
- `npm run typecheck` (fails: missing modules and type errors)


------
https://chatgpt.com/codex/tasks/task_e_68a9b77c4724832485580e397030b857