### PR TITLE
Use boolean for ricorrenza is_active field

### DIFF
--- a/Frontend-nextjs/app/(protected)/home/cards/ProssimoPagamentoCard.tsx
+++ b/Frontend-nextjs/app/(protected)/home/cards/ProssimoPagamentoCard.tsx
@@ -25,7 +25,7 @@ export default function ProssimoPagamentoCard() {
     // Filtro: solo attive e con prossima >= oggi
     const oggi = new Date();
     const future = ricorrenze
-        .filter((r) => !!r.is_active && new Date(r.prossima) >= oggi)
+        .filter((r) => r.is_active && new Date(r.prossima) >= oggi)
         .sort((a, b) => new Date(a.prossima).getTime() - new Date(b.prossima).getTime());
 
     const prossimo = future[0];

--- a/Frontend-nextjs/app/(protected)/home/cards/RicorrentiCard.tsx
+++ b/Frontend-nextjs/app/(protected)/home/cards/RicorrentiCard.tsx
@@ -13,7 +13,7 @@ export default function RicorrentiCard() {
     useRenderTimer("RicorrentiCard");
     const { ricorrenze, loading } = useRicorrenze();
 
-    const attive = useMemo(() => ricorrenze.filter((r) => !!r.is_active), [ricorrenze]);
+    const attive = useMemo(() => ricorrenze.filter((r) => r.is_active), [ricorrenze]);
 
     // Calcolo statistiche
     const totali = useMemo(() => {

--- a/Frontend-nextjs/app/(protected)/newRicorrenza/NewRicorrenzaForm.tsx
+++ b/Frontend-nextjs/app/(protected)/newRicorrenza/NewRicorrenzaForm.tsx
@@ -8,6 +8,7 @@ import { useState, useMemo, useEffect } from "react";
 import { RicorrenzaBase } from "@/types/models/ricorrenza";
 import type { NewRicorrenzaFormProps } from "@/types";
 import { useCategories } from "@/context/CategoriesContext";
+import type { Category } from "@/types/models/category";
 import { Input } from "@/app/components/ui/Input";
 import { Textarea } from "@/app/components/ui/Textarea";
 import { Button } from "@/app/components/ui/Button";
@@ -38,7 +39,7 @@ export default function NewRicorrenzaForm({ onSave, onCancel, initialValues, onC
         category_id: initialValues?.category_id || 0,
         notes: initialValues?.notes || "",
         type: initialValues?.type || "entrata",
-        is_active: initialValues?.is_active ?? 1,
+        is_active: initialValues?.is_active ?? true,
         interval: initialValues?.interval || 1,
     });
     const [errors, setErrors] = useState<Record<string, string>>({});
@@ -52,7 +53,7 @@ export default function NewRicorrenzaForm({ onSave, onCancel, initialValues, onC
                 ...initialValues,
                 prossima: toDateInputValue(initialValues.prossima),
                 importo: initialValues.importo ?? 0,
-                is_active: initialValues.is_active ?? 1,
+                is_active: initialValues.is_active ?? true,
                 interval: initialValues.interval ?? 1,
             }));
         }
@@ -65,7 +66,7 @@ export default function NewRicorrenzaForm({ onSave, onCancel, initialValues, onC
 
     // ==================== CATEGORY FILTER ====================
     const filteredCategories = useMemo(
-        () => categories.filter((cat) => cat.type === formData.type),
+        () => categories.filter((cat: Category) => cat.type === formData.type),
         [categories, formData.type]
     );
 
@@ -134,7 +135,7 @@ export default function NewRicorrenzaForm({ onSave, onCancel, initialValues, onC
                     <option value={0} disabled>
                         {loadingCategories ? "Caricamento..." : "Seleziona categoria"}
                     </option>
-                    {filteredCategories.map((cat) => (
+                    {filteredCategories.map((cat: Category) => (
                         <option key={cat.id} value={cat.id}>
                             {cat.name}
                         </option>

--- a/Frontend-nextjs/lib/api/ricorrenzeApi.ts
+++ b/Frontend-nextjs/lib/api/ricorrenzeApi.ts
@@ -63,7 +63,7 @@ export async function createRicorrenza(token: string, data: RicorrenzaBase): Pro
         frequency: frequencyToBackend(data.frequenza), // IT → EN
         interval: data.interval || 1, // default 1
         start_date: data.prossima, // "prossima" → "start_date"
-        is_active: data.is_active ?? 1, // default 1
+        is_active: data.is_active ?? true, // default true
         category_id: data.category_id,
         notes: data.notes ?? "",
         type: data.type, // opzionale, se richiesto
@@ -98,7 +98,7 @@ export async function updateRicorrenza(token: string, id: number, data: Ricorren
         frequency: frequencyToBackend(data.frequenza),
         interval: data.interval || 1,
         start_date: data.prossima,
-        is_active: Number(data.is_active ?? 1),
+        is_active: data.is_active ?? true,
         category_id: data.category_id,
         notes: data.notes ?? "",
         type: data.type,

--- a/Frontend-nextjs/types/models/ricorrenza.ts
+++ b/Frontend-nextjs/types/models/ricorrenza.ts
@@ -17,7 +17,7 @@ export type Ricorrenza = {
 
     notes: string;
     type: "entrata" | "spesa";
-    is_active: number; // <--- puoi aggiungerlo se il backend lo restituisce (opzionale)
+    is_active: boolean; // stato della regola (true=attiva)
     interval: number; // <--- idem, opzionale
 };
 
@@ -32,7 +32,7 @@ export type RicorrenzaBase = {
     category_id: number; // Categoria collegata
     notes: string; // Note opzionali
     type: "entrata" | "spesa"; // Tipo
-    is_active: number; // 1=attiva, 0=disattivata (obbligatorio)
+    is_active: boolean; // true=attiva, false=disattivata (obbligatorio)
     interval: number; // Quanti intervalli tra una ricorrenza e l'altra (es: 1=ogni mese)
 };
 

--- a/Frontend-nextjs/utils/normalizeRicorrenza.ts
+++ b/Frontend-nextjs/utils/normalizeRicorrenza.ts
@@ -17,11 +17,11 @@ const toNum = (v: unknown) => {
     return 0;
 };
 
-const to01 = (v: unknown) => {
-    if (typeof v === "boolean") return v ? 1 : 0;
-    if (typeof v === "number") return v ? 1 : 0;
-    if (typeof v === "string") return ["1", "true", "TRUE", "True", "yes", "on"].includes(v) ? 1 : 0;
-    return 0;
+const toBool = (v: unknown): boolean => {
+    if (typeof v === "boolean") return v;
+    if (typeof v === "number") return v !== 0;
+    if (typeof v === "string") return ["1", "true", "TRUE", "True", "yes", "on"].includes(v);
+    return false;
 };
 
 // ─────────────────────────────────────────────────────────────
@@ -44,8 +44,7 @@ export function normalizeRicorrenza(r: any): Ricorrenza {
         notes: r.note ?? r.notes ?? "",
         type: r.type === "entrata" ? "entrata" : r.category?.type ?? "spesa",
 
-        // ⚠️ il tuo tipo Richiede number → 0/1
-        is_active: typeof r.is_active !== "undefined" ? to01(r.is_active) : 1,
+        is_active: typeof r.is_active !== "undefined" ? toBool(r.is_active) : true,
 
         interval: typeof r.interval !== "undefined" ? Number(r.interval) : 1,
     } as Ricorrenza;


### PR DESCRIPTION
## Summary
- refactor ricorrenza types to use boolean `is_active`
- normalize API data and requests to handle boolean active flag
- adjust front-end forms and cards for boolean `is_active`

## Testing
- `npm run typecheck` *(fails: Parameter 'c' implicitly has an 'any' type, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b95178d4832499e9ebc4089f87d3