### PR TITLE
chore: add repository-wide scripts for audits and dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,15 @@ cp .env.example .env
 npm run dev
 ```
 
+## 🧰 Scripts utili
+
+All'interno della cartella [`scripts/`](scripts) trovi alcuni script comuni:
+
+- `audit-all.sh` / `audit-all.ps1` – eseguono lint, typecheck, build e test per Backend, Frontend e ML.
+- `check-routes.ts` – verifica la raggiungibilità delle rotte API (accetta base URL e token opzionali).
+- `ml_smoke_test.ps1` – smoke test per il microservizio ML e l'endpoint Laravel (`MlBase`, `ApiBase`, `Token`).
+- `dev-all.ps1` – avvia in parallelo i servizi di sviluppo.
+
 ---
 
 ## 🔒 Protezione utente demo

--- a/scripts/audit-all.ps1
+++ b/scripts/audit-all.ps1
@@ -1,0 +1,26 @@
+#!/usr/bin/env pwsh
+set-strictmode -version latest
+
+Write-Host "=== Backend: lint/typecheck/build/test ==="
+Push-Location Backend
+if(Test-Path vendor/bin/pint){ & vendor/bin/pint --test }
+if(Test-Path vendor/bin/phpstan){ & vendor/bin/phpstan analyse }
+npm run build --if-present
+composer test
+Pop-Location
+
+Write-Host "=== Frontend: lint/typecheck/build/test ==="
+Push-Location Frontend-nextjs
+npm run lint
+npm run typecheck
+npm run build
+npm test --if-present
+Pop-Location
+
+Write-Host "=== ML: lint/typecheck/build/test ==="
+Push-Location ml_category_suggester
+python -m py_compile category_suggester_service.py
+if(Test-Path tests){ pytest }
+Pop-Location
+
+Write-Host "Audit completed"

--- a/scripts/audit-all.sh
+++ b/scripts/audit-all.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Backend
+echo "=== Backend: lint/typecheck/build/test ==="
+(
+  cd Backend
+  if [ -f vendor/bin/pint ]; then vendor/bin/pint --test; fi
+  if [ -f vendor/bin/phpstan ]; then vendor/bin/phpstan analyse; fi
+  npm run build --if-present
+  composer test
+)
+
+# Frontend
+echo "=== Frontend: lint/typecheck/build/test ==="
+(
+  cd Frontend-nextjs
+  npm run lint
+  npm run typecheck
+  npm run build
+  npm test --if-present
+)
+
+# ML
+echo "=== ML: lint/typecheck/build/test ==="
+(
+  cd ml_category_suggester
+  python -m py_compile category_suggester_service.py
+  if [ -d tests ]; then pytest; fi
+)
+
+echo "Audit completed"

--- a/scripts/check-routes.ts
+++ b/scripts/check-routes.ts
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+import { API } from "../Frontend-nextjs/src/lib/api/endpoints.ts";
+
+const [baseArg, token] = process.argv.slice(2);
+const base = baseArg || process.env.API_BASE_URL || "http://127.0.0.1:8000";
+const headers = token ? { Authorization: `Bearer ${token}` } : {};
+
+const keys = Object.keys(API).filter((k) => k !== "base");
+for (const key of keys) {
+  const path = API[key as keyof typeof API];
+  const target = `${base}${path}`;
+  try {
+    const res = await fetch(target, { method: "HEAD", headers });
+    const ok = res.ok || res.status === 401;
+    console.log(`${path} - ${ok ? "OK" : `ERR ${res.status}`}`);
+  } catch (err) {
+    console.log(`${path} - ERR ${(err as Error).message}`);
+  }
+}

--- a/scripts/dev-all.ps1
+++ b/scripts/dev-all.ps1
@@ -1,0 +1,10 @@
+#!/usr/bin/env pwsh
+set-strictmode -version latest
+
+$jobs = @()
+$jobs += Start-Job { Set-Location Backend; npm run dev }
+$jobs += Start-Job { Set-Location Frontend-nextjs; npm run dev }
+$jobs += Start-Job { python ml_category_suggester/category_suggester_service.py }
+
+Write-Host "Dev services started. Press Ctrl+C to stop."
+Wait-Job $jobs

--- a/scripts/ml_smoke_test.ps1
+++ b/scripts/ml_smoke_test.ps1
@@ -1,0 +1,77 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Sezione: Utils stampa
+# Dettagli: funzioni helper colorate
+# ─────────────────────────────────────────────────────────────────────────────
+function Write-Ok($msg){ Write-Host "✅ $msg" -ForegroundColor Green }
+function Write-Warn($msg){ Write-Host "⚠️ $msg" -ForegroundColor Yellow }
+function Write-Err($msg){ Write-Host "❌ $msg" -ForegroundColor Red }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Sezione: HTTP helper
+# Dettagli: invoca endpoint JSON
+# ─────────────────────────────────────────────────────────────────────────────
+function Invoke-Json($method,$url,$headers,$body=$null){
+    try{
+        $params=@{Method=$method;Uri=$url;Headers=$headers;ContentType="application/json";TimeoutSec=5}
+        if($body){$params.Body=($body|ConvertTo-Json)}
+        return Invoke-RestMethod @params
+    }catch{throw}
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Sezione: Test ML
+# Dettagli: health + prediction
+# ─────────────────────────────────────────────────────────────────────────────
+function Test-Health($mlBase){
+    try{
+        $res=Invoke-Json 'GET' "$mlBase/health" @{}
+        if($res.status -eq 'ok'){Write-Ok "ML health";return $true}
+        Write-Err "ML health payload";return $false
+    }catch{Write-Err "ML health $_";return $false}
+}
+
+function Test-PredictPizza($mlBase){
+    try{
+        $res=Invoke-Json 'POST' "$mlBase/predict-category" @{} @{description="Pizza Margherita"}
+        if($res.category -eq 'cibo' -and [double]$res.confidence -ge 0.9){Write-Ok "ML predict";return $true}
+        Write-Err "ML predict mismatch";return $false
+    }catch{Write-Err "ML predict $_";return $false}
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Sezione: Test Laravel
+# Dettagli: suggest category via Sanctum
+# ─────────────────────────────────────────────────────────────────────────────
+function Test-LaravelSuggest($apiBase,$token){
+    try{
+        $h=@{Authorization="Bearer $token"}
+        $res=Invoke-Json 'POST' "$apiBase/api/v1/ml/suggest-category" $h @{description="Affitto agosto"}
+        if($res.category -eq 'casa' -and [double]$res.confidence -ge 0.7){Write-Ok "Laravel suggest";return $true}
+        Write-Err "Laravel suggest mismatch";return $false
+    }catch{Write-Err "Laravel suggest $_";return $false}
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Sezione: Main
+# Dettagli: orchestrazione smoke test
+# ─────────────────────────────────────────────────────────────────────────────
+param(
+    [string]$MlBase="http://127.0.0.1:7001",
+    [string]$ApiBase="http://127.0.0.1:8000",
+    [string]$Token=""
+)
+
+Write-Host "ML Base: $MlBase"
+Write-Host "API Base: $ApiBase"
+if($Token){Write-Host "Token: ****"}else{Write-Warn "Token assente"}
+
+$all=$true
+$all=(Test-Health $MlBase) -and $all
+$all=(Test-PredictPizza $MlBase) -and $all
+if($Token){$all=(Test-LaravelSuggest $ApiBase $Token) -and $all}else{Write-Warn "Laravel skipped"}
+
+if($all){Write-Ok "Smoke test completed";exit 0}else{Write-Err "Smoke test failed";exit 1}
+
+# Esempi:
+# powershell -ExecutionPolicy Bypass -File .\scripts\ml_smoke_test.ps1
+# powershell -ExecutionPolicy Bypass -File .\scripts\ml_smoke_test.ps1 -MlBase http://localhost:7001 -ApiBase http://localhost:8000 -Token "<SANCTUM_TOKEN>"


### PR DESCRIPTION
## Summary
- add `scripts/` folder with audit, route check, smoke test and dev helper scripts
- orchestrate lint/typecheck/build/test across Backend, Frontend and ML
- document new scripts in README

## Testing
- `bash scripts/audit-all.sh` *(fails: Modules/RecurringOperations/... style issues)*
- `node scripts/check-routes.ts http://127.0.0.1:8000`
- `pwsh scripts/ml_smoke_test.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b952f3d88324afe9d3e3239375fb