### PR TITLE
Cache financial overview data per user

### DIFF
--- a/Backend/Modules/Entrate/Observers/EntrataObserver.php
+++ b/Backend/Modules/Entrate/Observers/EntrataObserver.php
@@ -2,6 +2,7 @@
 
 namespace Modules\Entrate\Observers;
 
+use Illuminate\Support\Facades\Cache;
 use Modules\AuditTrail\Services\AuditTrailService;
 use Modules\Entrate\Models\Entrata;
 
@@ -21,6 +22,8 @@ class EntrataObserver
             null,
             $entrata->toArray()
         );
+
+        $this->clearCache($entrata->user_id);
     }
 
     /**
@@ -34,6 +37,8 @@ class EntrataObserver
             $entrata->getOriginal(),   // Stato precedente
             $entrata->toArray()        // Stato attuale
         );
+
+        $this->clearCache($entrata->user_id);
     }
 
     /**
@@ -47,6 +52,8 @@ class EntrataObserver
             $entrata->getOriginal(),
             null
         );
+
+        $this->clearCache($entrata->user_id);
     }
 
     /**
@@ -60,6 +67,8 @@ class EntrataObserver
             $entrata->getOriginal(),
             $entrata->toArray()
         );
+
+        $this->clearCache($entrata->user_id);
     }
 
     /**
@@ -73,6 +82,13 @@ class EntrataObserver
             $entrata->getOriginal(),
             null
         );
+
+        $this->clearCache($entrata->user_id);
+    }
+
+    protected function clearCache(int $userId): void
+    {
+        Cache::tags(['financial_overview', 'user:' . $userId])->flush();
     }
 }
 

--- a/Backend/Modules/Spese/Observers/SpesaObserver.php
+++ b/Backend/Modules/Spese/Observers/SpesaObserver.php
@@ -2,6 +2,7 @@
 
 namespace Modules\Spese\Observers;
 
+use Illuminate\Support\Facades\Cache;
 use Modules\AuditTrail\Services\AuditTrailService;
 use Modules\Spese\Models\Spesa;
 
@@ -21,6 +22,8 @@ class SpesaObserver
             null,
             $spesa->toArray()
         );
+
+        $this->clearCache($spesa->user_id);
     }
 
     /**
@@ -34,6 +37,8 @@ class SpesaObserver
             $spesa->getOriginal(),   // Stato precedente
             $spesa->toArray()        // Stato attuale
         );
+
+        $this->clearCache($spesa->user_id);
     }
 
     /**
@@ -47,6 +52,8 @@ class SpesaObserver
             $spesa->getOriginal(),
             null
         );
+
+        $this->clearCache($spesa->user_id);
     }
 
     /**
@@ -60,6 +67,8 @@ class SpesaObserver
             $spesa->getOriginal(),
             $spesa->toArray()
         );
+
+        $this->clearCache($spesa->user_id);
     }
 
     /**
@@ -73,6 +82,13 @@ class SpesaObserver
             $spesa->getOriginal(),
             null
         );
+
+        $this->clearCache($spesa->user_id);
+    }
+
+    protected function clearCache(int $userId): void
+    {
+        Cache::tags(['financial_overview', 'user:' . $userId])->flush();
     }
 }
 


### PR DESCRIPTION
## Summary
- cache financial overview results per user and filters
- flush cached overviews when income or expense transactions change

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68ac50616c488324b4e2e27c18234aa2