### PR TITLE
fix: tune CORS for prod and add fetch diagnostics

### DIFF
--- a/Backend/config/cors.php
+++ b/Backend/config/cors.php
@@ -1,7 +1,7 @@
 <?php
 
 // ─────────────────────────────────────────────────────────────────────────────
-// config/cors.php — DEV (token/Bearer, niente cookie)
+// config/cors.php — PROD (Bearer token, no cross-site cookies)
 // ─────────────────────────────────────────────────────────────────────────────
 
 return [
@@ -15,9 +15,15 @@ return [
 
     // ── Metodi / Header ──
     'allowed_methods' => ['*'],
-    'allowed_headers' => ['*'],
+    'allowed_headers' => [
+        'Content-Type',
+        'X-Requested-With',
+        'Authorization',
+        'Accept',
+        'Origin',
+    ],
 
-    // ── Origin del frontend in DEV ──
+    // ── Origin del frontend ──
     'allowed_origins' => [
         'http://localhost:8083',        // Expo Web
         'http://192.168.0.111:8083',    // Expo Web via IP
@@ -28,14 +34,16 @@ return [
         'https://synapsy-frontend.vercel.app',
     ],
 
-    // ── Pattern (non indispensabile qui) ──
-    'allowed_origins_patterns' => [],
+    // ── Pattern per deploy Vercel (preview) ──
+    'allowed_origins_patterns' => [
+        '#^https://synapsy-frontend-.*\\.vercel\\.app$#',
+    ],
 
     // ── Header esposti al browser (se invii token in header) ──
     'exposed_headers' => ['Authorization'],
 
     // ── Cache preflight ──
-    'max_age' => 0,
+    'max_age' => 600,
 
     // ── IMPORTANTE: niente cookie/sessioni cross-site ──
     'supports_credentials' => false,

--- a/Frontend-nextjs/lib/api/userApi.ts
+++ b/Frontend-nextjs/lib/api/userApi.ts
@@ -9,16 +9,41 @@ import { url } from "@/lib/api/endpoints";
 // GET profilo corrente
 // ==============================
 export async function fetchUserProfile(token: string): Promise<UserType> {
-    const res = await fetch(url("profile"), {
-        headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-            Accept: "application/json",
-        },
-    });
-    if (!res.ok) throw new Error("Errore caricamento profilo");
-    const data = await res.json();
-    return data.data || data;
+    const endpoint = url("profile");
+    try {
+        const res = await fetch(endpoint, {
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${token}`,
+                Accept: "application/json",
+            },
+        });
+
+        const bodyText = await res.text();
+        let body: any = null;
+        try {
+            body = JSON.parse(bodyText);
+        } catch {
+            body = bodyText;
+        }
+
+        if (!res.ok) {
+            console.error("[fetchUserProfile] fetch failed", {
+                url: endpoint,
+                status: res.status,
+                body: typeof body === "string" ? body.slice(0, 200) : body,
+            });
+            throw new Error(body?.message || "Errore caricamento profilo");
+        }
+
+        return body.data || body;
+    } catch (err) {
+        console.error("[fetchUserProfile] network error", {
+            url: endpoint,
+            error: err,
+        });
+        throw err;
+    }
 }
 
 // ==============================


### PR DESCRIPTION
## Summary
- tighten CORS headers and allow Vercel previews
- log profile fetch failures with status/url/body snippet

## Testing
- `composer test`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1d09eee3c83249f58164a5b8f719d