### PR TITLE
Normalize EUR formatting across UI

### DIFF
--- a/Frontend-nextjs/app/(protected)/home/cards/ProssimoPagamentoCard.tsx
+++ b/Frontend-nextjs/app/(protected)/home/cards/ProssimoPagamentoCard.tsx
@@ -11,9 +11,7 @@ import LoadingSpinnerCard from "./loading/LoadingSpinnerCard";
 import { useRicorrenze } from "@/context/RicorrenzeContext";
 import { useRenderTimer } from "@/app/(protected)/home/utils/useRenderTimer";
 import { formatDataIt } from "@/utils/date";
-
-// ── Helper: € formattato ────────────────────────────
-const eur = new Intl.NumberFormat("it-IT", { style: "currency", currency: "EUR" });
+import { eur } from "@/utils/formatCurrency";
 
 // ===============================
 // Componente principale
@@ -65,7 +63,7 @@ export default function ProssimoPagamentoCard() {
     const data = formatDataIt(prossimo.prossima);
     const isSpesa = prossimo.type === "spesa";
     const importoAbs = Math.abs(Number(prossimo.importo) || 0);
-    const importoTxt = eur.format(importoAbs);
+    const importoTxt = eur(importoAbs);
     const importoClass = isSpesa ? "text-red-600 dark:text-red-400" : "text-emerald-600 dark:text-emerald-400";
     const simbolo = isSpesa ? "−" : "+";
     const nome = prossimo.nome || "—";

--- a/Frontend-nextjs/app/(protected)/home/hero/heroItems/HeroSaldo.tsx
+++ b/Frontend-nextjs/app/(protected)/home/hero/heroItems/HeroSaldo.tsx
@@ -1,14 +1,8 @@
 "use client";
 
 import { useTransactions } from "@/context/TransactionsContext";
+import { eur } from "@/utils/formatCurrency";
 
-function formatCurrency(value: number) {
-    return value.toLocaleString("it-IT", {
-        style: "currency",
-        currency: "EUR",
-        minimumFractionDigits: 2,
-    });
-}
 function color(value: number) {
     return value >= 0 ? "text-emerald-500" : "text-red-500";
 }
@@ -26,22 +20,22 @@ export default function HeroSaldo() {
 
                 <p className="text-base mb-1">
                     <span className="font-medium">Settimana:</span>{" "}
-                    <span className={`font-semibold ${color(weekBalance)}`}>{formatCurrency(weekBalance)}</span>
+                    <span className={`font-semibold ${color(weekBalance)}`}>{eur(weekBalance)}</span>
                 </p>
 
                 <p className="text-base mb-1">
                     <span className="font-medium">Mese ({currentMonthName}):</span>{" "}
-                    <span className={`font-semibold ${color(monthBalance)}`}>{formatCurrency(monthBalance)}</span>
+                    <span className={`font-semibold ${color(monthBalance)}`}>{eur(monthBalance)}</span>
                 </p>
 
                 <p className="text-base mb-1">
                     <span className="font-medium">Anno ({currentYear}):</span>{" "}
-                    <span className={`font-semibold ${color(yearBalance)}`}>{formatCurrency(yearBalance)}</span>
+                    <span className={`font-semibold ${color(yearBalance)}`}>{eur(yearBalance)}</span>
                 </p>
 
                 <p className="text-base mb-2">
                     <span className="font-medium">Totale:</span>{" "}
-                    <span className={`font-semibold ${color(totalBalance)}`}>{formatCurrency(totalBalance)}</span>
+                    <span className={`font-semibold ${color(totalBalance)}`}>{eur(totalBalance)}</span>
                 </p>
             </div>
         </div>

--- a/Frontend-nextjs/app/(protected)/newRicorrenza/NewRicorrenzaForm.tsx
+++ b/Frontend-nextjs/app/(protected)/newRicorrenza/NewRicorrenzaForm.tsx
@@ -172,7 +172,7 @@ export default function NewRicorrenzaForm({ onSave, onCancel, initialValues, onC
                     step="0.01"
                     placeholder="Importo"
                     value={formData.importo === 0 ? "" : formData.importo}
-                    onChange={(e) => setFormData({ ...formData, importo: parseFloat(e.target.value) || 0 })}
+                    onChange={(e) => setFormData({ ...formData, importo: Number(e.target.value) || 0 })}
                     className={errors.importo ? "border-danger" : ""}
                 />
                 {errors.importo && <p className="text-danger text-xs -mt-2">{errors.importo}</p>}

--- a/Frontend-nextjs/app/(protected)/newRicorrenza/NewRicorrenzaModal.tsx
+++ b/Frontend-nextjs/app/(protected)/newRicorrenza/NewRicorrenzaModal.tsx
@@ -11,6 +11,7 @@ import NewRicorrenzaForm from "./NewRicorrenzaForm";
 import { useCategories } from "@/context/CategoriesContext";
 import { Ricorrenza, RicorrenzaBase } from "@/types/models/ricorrenza";
 import type { NewRicorrenzaModalProps } from "@/types";
+import { eur } from "@/utils/formatCurrency";
 
 // ============================
 // Componente principale
@@ -65,7 +66,7 @@ export default function NewRicorrenzaModal({ open, onClose, ricorrenzaToEdit, on
                             <>
                                 {`• Nome: "${ricorrenzaToEdit.nome}"`}
                                 <br />
-                                {`• Importo: ${ricorrenzaToEdit.importo} €`}
+                                {`• Importo: ${eur(ricorrenzaToEdit.importo)}`}
                                 <br />
                                 {`• Frequenza: ${ricorrenzaToEdit.frequenza}`}
                                 <br />
@@ -75,7 +76,7 @@ export default function NewRicorrenzaModal({ open, onClose, ricorrenzaToEdit, on
                             <>
                                 {`• Nome: "${formValues.nome}"`}
                                 <br />
-                                {formValues.importo && `• Importo: ${formValues.importo} €`}
+                                {formValues.importo && `• Importo: ${eur(formValues.importo)}`}
                                 <br />
                                 {formValues.frequenza && `• Frequenza: ${formValues.frequenza}`}
                                 <br />

--- a/Frontend-nextjs/app/(protected)/newTransaction/NewTransactionForm.tsx
+++ b/Frontend-nextjs/app/(protected)/newTransaction/NewTransactionForm.tsx
@@ -190,7 +190,7 @@ export default function NewTransactionForm({
                     onChange={(e) =>
                         setFormData({
                             ...formData,
-                            amount: parseFloat(e.target.value) || 0,
+                            amount: Number(e.target.value) || 0,
                         })
                     }
                     className={cn(errors.amount ? "border-danger" : "")}

--- a/Frontend-nextjs/app/(protected)/newTransaction/NewTransactionModal.tsx
+++ b/Frontend-nextjs/app/(protected)/newTransaction/NewTransactionModal.tsx
@@ -10,6 +10,7 @@ import LoadingOverlay from "@/app/components/ui/LoadingOverlay";
 import NewTransactionForm from "./NewTransactionForm";
 import { useTransactions } from "@/context/TransactionsContext";
 import { useCategories } from "@/context/CategoriesContext";
+import { eur } from "@/utils/formatCurrency";
 
 // ============================
 // Componente principale
@@ -72,7 +73,7 @@ export default function NewTransactionModal({
                             <>
                                 {`• Descrizione: "${transactionToEdit.description}"`}
                                 <br />
-                                {`• Importo: ${transactionToEdit.amount} €`}
+                                {`• Importo: ${eur(transactionToEdit.amount)}`}
                                 <br />
                                 {transactionToEdit.date && `• Data: ${transactionToEdit.date}`}
                                 <br />
@@ -82,7 +83,7 @@ export default function NewTransactionModal({
                             <>
                                 {`• Descrizione: "${formValues.description}"`}
                                 <br />
-                                {formValues.amount && `• Importo: ${formValues.amount} €`}
+                                {formValues.amount && `• Importo: ${eur(formValues.amount)}`}
                                 <br />
                                 {formValues.date && `• Data: ${formValues.date}`}
                                 <br />

--- a/Frontend-nextjs/app/(protected)/panoramica/components/calendar/DayCell.tsx
+++ b/Frontend-nextjs/app/(protected)/panoramica/components/calendar/DayCell.tsx
@@ -9,10 +9,11 @@
 
 import { Transaction } from "@/types/models/transaction";
 import type { DayCellProps } from "@/types";
+import { eur } from "@/utils/formatCurrency";
 
 // ----------- Funzione somma importi ----------- //
 const somma = (arr: Transaction[]) =>
-    arr.reduce((tot, t) => tot + (typeof t.amount === "string" ? parseFloat(t.amount) : t.amount), 0);
+    arr.reduce((tot, t) => tot + (typeof t.amount === "string" ? Number(t.amount) : t.amount), 0);
 
 // ----------- Componente principale ----------- //
 export default function DayCell({
@@ -60,8 +61,8 @@ export default function DayCell({
     const tooltip =
         transactions.length === 0
             ? ""
-            : `Entrate: ${entrate.length} (${totaleEntrate.toFixed(2)}€)\n
-                Spese: ${spese.length} (${totaleSpese.toFixed(2)}€)`;
+            : `Entrate: ${entrate.length} (${eur(totaleEntrate)})\n
+                Spese: ${spese.length} (${eur(totaleSpese)})`;
 
     // -------------------------- //
     // ------- RENDER UI -------- //
@@ -114,7 +115,7 @@ export default function DayCell({
                             style={{ height: `${barEntrate}px`, minHeight: `${minHeight}px` }}
                         >
                             <span className="absolute bottom-0 left-1/2 -translate-x-1/2 text-[10px] text-bg font-semibold">
-                                {Math.round(totaleEntrate)}€
+                                {eur(Math.round(totaleEntrate))}
                             </span>
                         </div>
                         <span className="mt-0.5 text-[8px] text-primary font-semibold">Entrate</span>
@@ -128,7 +129,7 @@ export default function DayCell({
                             style={{ height: `${barSpese}px`, minHeight: `${minHeight}px` }}
                         >
                             <span className="absolute bottom-0 left-1/2 -translate-x-1/2 text-[10px] text-bg font-semibold">
-                                {Math.round(totaleSpese)}€
+                                {eur(Math.round(totaleSpese))}
                             </span>
                         </div>
                         <span className="mt-0.5 text-[8px] text-orange-400 font-semibold">Spese</span>

--- a/Frontend-nextjs/app/(protected)/panoramica/components/modal/DayTransactionsModal.tsx
+++ b/Frontend-nextjs/app/(protected)/panoramica/components/modal/DayTransactionsModal.tsx
@@ -6,6 +6,7 @@ import { Transaction } from "@/types/models/transaction";
 import { useTransactions } from "@/context/TransactionsContext";
 import { CATEGORY_ICONS_MAP } from "@/utils/categoryOptions";
 import { toDateInputValue } from "@/utils/date";
+import { eur } from "@/utils/formatCurrency";
 import { FiTag } from "react-icons/fi";
 
 export type DayTransactionsModalProps = {
@@ -22,7 +23,7 @@ export default function DayTransactionsModal({ open, onClose, date, transactions
     const entrate = transactions.filter((t) => t.category?.type === "entrata");
     const spese = transactions.filter((t) => t.category?.type === "spesa");
     const somma = (arr: Transaction[]) =>
-        arr.reduce((tot, t) => tot + (typeof t.amount === "string" ? parseFloat(t.amount as any) : t.amount), 0);
+        arr.reduce((tot, t) => tot + (typeof t.amount === "string" ? Number(t.amount) : t.amount), 0);
     const totalEntrate = somma(entrate);
     const totalSpese = somma(spese);
 
@@ -71,9 +72,9 @@ export default function DayTransactionsModal({ open, onClose, date, transactions
                                     </td>
                                 </tr>
                                 <tr className="text-lg font-bold">
-                                    <td className="text-primary">+{totalEntrate.toFixed(2)}€</td>
-                                    <td className="text-orange-500">-{totalSpese.toFixed(2)}€</td>
-                                    <td className="text-primary">{(totalEntrate - totalSpese).toFixed(2)}€</td>
+                                    <td className="text-primary">+{eur(totalEntrate)}</td>
+                                    <td className="text-orange-500">-{eur(totalSpese)}</td>
+                                    <td className="text-primary">{eur(totalEntrate - totalSpese)}</td>
                                 </tr>
                             </tbody>
                         </table>
@@ -115,10 +116,11 @@ export default function DayTransactionsModal({ open, onClose, date, transactions
                                                 t.category?.type === "entrata" ? "text-primary" : "text-orange-500"
                                             }`}
                                         >
-                                            {typeof t.amount === "string"
-                                                ? parseFloat(t.amount).toFixed(2)
-                                                : t.amount.toFixed(2)}
-                                            €
+                                            {(() => {
+                                                const amount =
+                                                    typeof t.amount === "string" ? Number(t.amount) : t.amount;
+                                                return eur(amount);
+                                            })()}
                                         </span>
                                         <button
                                             type="button"

--- a/Frontend-nextjs/app/(protected)/ricorrenti/Card/CardTotaliAnnui.tsx
+++ b/Frontend-nextjs/app/(protected)/ricorrenti/Card/CardTotaliAnnui.tsx
@@ -9,6 +9,7 @@ import { aggregaRicorrenzePerTipoEFrequenza, frequenzaOrder, sommaTotaleAnnua } 
 import { Ricorrenza } from "@/types/models/ricorrenza";
 import type { CardTotaliAnnuiProps } from "@/types/ricorrenti/card";
 import NewRicorrenzaButton from "@/app/(protected)/newRicorrenza/NewRicorrenzaButton";
+import { eur } from "@/utils/formatCurrency";
 
 // ============================
 // Props tipizzate
@@ -144,17 +145,17 @@ export default function CardTotaliAnnui({ ricorrenze }: CardTotaliAnnuiProps) {
                                     </td>
                                     {/* Valori Spese */}
                                     <td className="px-2 py-1 font-mono text-[hsl(var(--c-table-danger-2))]">
-                                        €{(aggregato.spesa[freq]?.totale ?? 0).toFixed(2)}
+                                        {eur(aggregato.spesa[freq]?.totale ?? 0)}
                                     </td>
                                     <td className="px-2 py-1 font-mono text-[hsl(var(--c-table-danger-2))]">
-                                        €{(aggregato.spesa[freq]?.totaleAnnuale ?? 0).toFixed(2)}
+                                        {eur(aggregato.spesa[freq]?.totaleAnnuale ?? 0)}
                                     </td>
                                     {/* Valori Entrate */}
                                     <td className="px-2 py-1 font-mono text-[hsl(var(--c-table-success-2))]">
-                                        €{(aggregato.entrata[freq]?.totale ?? 0).toFixed(2)}
+                                        {eur(aggregato.entrata[freq]?.totale ?? 0)}
                                     </td>
                                     <td className="px-2 py-1 font-mono text-[hsl(var(--c-table-success-2))]">
-                                        €{(aggregato.entrata[freq]?.totaleAnnuale ?? 0).toFixed(2)}
+                                        {eur(aggregato.entrata[freq]?.totaleAnnuale ?? 0)}
                                     </td>
                                 </tr>
                             ))}
@@ -167,11 +168,11 @@ export default function CardTotaliAnnui({ ricorrenze }: CardTotaliAnnuiProps) {
                                 </td>
                                 <td className="px-2 py-1 font-bold font-mono text-[hsl(var(--c-table-danger-2))]"></td>
                                 <td className="px-2 py-1 font-bold font-mono text-[hsl(var(--c-table-danger-2))]">
-                                    €{totaleSpeseAnnue.toFixed(2)}
+                                    {eur(totaleSpeseAnnue)}
                                 </td>
                                 <td className="px-2 py-1 font-bold font-mono text-[hsl(var(--c-table-success-2))]"></td>
                                 <td className="px-2 py-1 font-bold font-mono text-[hsl(var(--c-table-success-2))]">
-                                    €{totaleEntrateAnnue.toFixed(2)}
+                                    {eur(totaleEntrateAnnue)}
                                 </td>
                             </tr>
                             <tr>
@@ -188,8 +189,8 @@ export default function CardTotaliAnnui({ ricorrenze }: CardTotaliAnnuiProps) {
                                             borderColor: "hsl(var(--c-total-positive-border))",
                                         }}
                                     >
-                                        Bilancio Ricorrenti Annui: {bilancioRicorrenti >= 0 ? "+" : "–"}€
-                                        {Math.abs(bilancioRicorrenti).toFixed(2)}
+                                        Bilancio Ricorrenti Annui: {bilancioRicorrenti >= 0 ? "+" : "–"}
+                                        {eur(Math.abs(bilancioRicorrenti))}
                                     </span>
                                 </td>
                             </tr>

--- a/Frontend-nextjs/app/(protected)/ricorrenti/liste/ListaProssimiPagamenti.tsx
+++ b/Frontend-nextjs/app/(protected)/ricorrenti/liste/ListaProssimiPagamenti.tsx
@@ -9,6 +9,7 @@ import type { ListaProssimiPagamentiProps, SectionOccorrenzeProps } from "@/type
 import { normalizzaFrequenza, freqToIt, freqToDays } from "../utils/ricorrenza-utils";
 import { Pencil, Trash2 } from "lucide-react";
 import { useCategories } from "@/context/CategoriesContext";
+import { eur } from "@/utils/formatCurrency";
 
 // ============================
 // Props tipizzate
@@ -195,10 +196,10 @@ export default function ListaProssimiPagamenti({
             {/* === Totali riepilogo === */}
             <div className="flex gap-4 mt-1 text-xs text-[hsl(var(--c-text-secondary))] flex-wrap">
                 <span>
-                    Settimana: <b>€{totaleSettimana.toFixed(2)}</b>
+                    Settimana: <b>{eur(totaleSettimana)}</b>
                 </span>
                 <span>
-                    Mese: <b>€{totaleMese.toFixed(2)}</b>
+                    Mese: <b>{eur(totaleMese)}</b>
                 </span>
             </div>
         </div>
@@ -225,7 +226,8 @@ function SectionOccorrenze({
                     className={`ml-2 px-2 py-0.5 rounded-lg text-xs font-bold border ${getBilancioUtility(bilancio)}`}
                     style={{ minWidth: 90, textAlign: "center" }}
                 >
-                    Bilancio: {bilancio >= 0 ? "+" : "–"}€{Math.abs(bilancio).toFixed(2)}
+                    Bilancio: {bilancio >= 0 ? "+" : "–"}
+                    {eur(Math.abs(bilancio))}
                 </span>
             </div>
             <ul className="divide-y divide-[hsl(var(--c-table-divider))]">
@@ -289,7 +291,8 @@ function SectionOccorrenze({
                                         className={`font-mono font-bold pr-1 ${textRow}`}
                                         style={{ minWidth: 64, textAlign: "right" }}
                                     >
-                                        {r.type === "entrata" ? "+" : "–"}€{(r.importo ?? 0).toFixed(2)}
+                                        {r.type === "entrata" ? "+" : "–"}
+                                        {eur(r.importo ?? 0)}
                                     </span>
                                     {/* Pill frequenza */}
                                     <span

--- a/Frontend-nextjs/app/(protected)/ricorrenti/liste/ListaRicorrenzeComponents/RicorrenzaItem.tsx
+++ b/Frontend-nextjs/app/(protected)/ricorrenti/liste/ListaRicorrenzeComponents/RicorrenzaItem.tsx
@@ -8,6 +8,7 @@ import { Ricorrenza } from "@/types/models/ricorrenza";
 import type { RicorrenzaItemProps } from "@/types/ricorrenti/liste";
 import { Pencil, Trash2 } from "lucide-react";
 import { getFreqPill } from "../../utils/ricorrenza-utils";
+import { eur } from "@/utils/formatCurrency";
 
 // --------- Utility per stile e simbolo importo ---------
 function getTypeStyle(type: "entrata" | "spesa") {
@@ -90,7 +91,8 @@ export default function RicorrenzaItem({ r, onEdit, onDelete }: RicorrenzaItemPr
 
             {/* Importo (col-2) */}
             <div className={`col-span-2 font-mono text-sm font-bold text-right ${valueClass}`}>
-                {symbol}€{(r.importo ?? 0).toFixed(2)}
+                {symbol}
+                {eur(r.importo ?? 0)}
             </div>
 
             {/* Azioni (col-2, centrato) */}

--- a/Frontend-nextjs/app/(protected)/ricorrenti/liste/ListaRicorrenzePerFrequenza.tsx
+++ b/Frontend-nextjs/app/(protected)/ricorrenti/liste/ListaRicorrenzePerFrequenza.tsx
@@ -10,6 +10,7 @@ import ConfirmDialog from "../../../components/ui/ConfirmDialog";
 import { Repeat } from "lucide-react";
 import { Ricorrenza } from "@/types/models/ricorrenza";
 import type { ListaRicorrenzePerFrequenzaProps } from "@/types/ricorrenti/liste";
+import { eur } from "@/utils/formatCurrency";
 
 // ============================
 // COSTANTI FREQUENZE & LABEL
@@ -99,7 +100,7 @@ export default function ListaRicorrenzePerFrequenza({ ricorrenze, onEdit, onDele
                     toDelete && (
                         <div className="flex flex-col items-center">
                             <span className="italic">{toDelete.nome}</span>
-                            {toDelete.importo && <span>{toDelete.importo.toFixed(2)}€</span>}
+                            {toDelete.importo && <span>{eur(toDelete.importo)}</span>}
                             {toDelete.categoria && <span>{toDelete.categoria}</span>}
                             {toDelete.frequenza && (
                                 <span className="text-xs">

--- a/Frontend-nextjs/app/(protected)/ricorrenti/utils/ricorrenza-utils.ts
+++ b/Frontend-nextjs/app/(protected)/ricorrenti/utils/ricorrenza-utils.ts
@@ -4,6 +4,7 @@
 // ============================
 
 import { Ricorrenza } from "@/types/models/ricorrenza";
+import { eur } from "@/utils/formatCurrency";
 
 // ╔══════════════════════════════════════════════════════╗
 // ║ 1. COSTANTI: ORDINE FREQUENZA E MOLTIPLICATORI      ║
@@ -146,7 +147,7 @@ export function buildBarChartOptions(saldoPerGiorno: number[] = []) {
                 callbacks: {
                     label: function (ctx: any) {
                         const idx = ctx.dataIndex;
-                        return `Saldo: €${ctx.dataset.data[idx].toFixed(2)}`;
+                        return `Saldo: ${eur(ctx.dataset.data[idx])}`;
                     },
                 },
             },

--- a/Frontend-nextjs/app/(protected)/transazioni/components/list/table/MonthDividerRow.tsx
+++ b/Frontend-nextjs/app/(protected)/transazioni/components/list/table/MonthDividerRow.tsx
@@ -4,6 +4,7 @@
 
 import { labelMeseAnno } from "./utils";
 import type { MonthDividerRowProps } from "@/types/transazioni/list";
+import { eur } from "@/utils/formatCurrency";
 
 export default function MonthDividerRow({ monthKey, colSpan, entrate = 0, spese = 0, saldo = 0, className }: MonthDividerRowProps) {
     return (
@@ -22,17 +23,11 @@ export default function MonthDividerRow({ monthKey, colSpan, entrate = 0, spese 
                     <span className="flex gap-3 items-center">
                         {/* Entrate */}
                         <span className="text-[hsl(var(--c-table-success-2))]">
-                            Entrate:{" "}
-                            <span className="font-bold">
-                                {entrate.toLocaleString("it-IT", { minimumFractionDigits: 2 })} €
-                            </span>
+                            Entrate: <span className="font-bold">{eur(entrate)}</span>
                         </span>
                         {/* Spese */}
                         <span className="text-[hsl(var(--c-table-danger-2))]">
-                            Spese:{" "}
-                            <span className="font-bold">
-                                {spese.toLocaleString("it-IT", { minimumFractionDigits: 2 })} €
-                            </span>
+                            Spese: <span className="font-bold">{eur(spese)}</span>
                         </span>
                         {/* Saldo */}
                         <span
@@ -42,10 +37,7 @@ export default function MonthDividerRow({ monthKey, colSpan, entrate = 0, spese 
                                     : "text-[hsl(var(--c-table-danger-2))]"
                             }
                         >
-                            <b>
-                                Saldo: {saldo >= 0 ? "+" : ""}
-                                {saldo.toLocaleString("it-IT", { minimumFractionDigits: 2 })} €
-                            </b>
+                            <b>Saldo: {eur(saldo)}</b>
                         </span>
                     </span>
                 </div>

--- a/Frontend-nextjs/app/(protected)/transazioni/components/list/table/YearDividerRow.tsx
+++ b/Frontend-nextjs/app/(protected)/transazioni/components/list/table/YearDividerRow.tsx
@@ -3,6 +3,7 @@
 // ╚══════════════════════════════════════════════════════╝
 
 import type { YearDividerRowProps } from "@/types/transazioni/list";
+import { eur } from "@/utils/formatCurrency";
 
 export default function YearDividerRow({
     year,
@@ -28,17 +29,11 @@ export default function YearDividerRow({
                     <span className="flex gap-5 items-center">
                         {/* Entrate */}
                         <span className="text-[hsl(var(--c-table-success-2))]">
-                            Entrate:{" "}
-                            <span className="font-bold">
-                                {entrate?.toLocaleString("it-IT", { minimumFractionDigits: 2 })} €
-                            </span>
+                            Entrate: <span className="font-bold">{eur(entrate)}</span>
                         </span>
                         {/* Spese */}
                         <span className="text-[hsl(var(--c-table-danger-2))]">
-                            Spese:{" "}
-                            <span className="font-bold">
-                                {spese?.toLocaleString("it-IT", { minimumFractionDigits: 2 })} €
-                            </span>
+                            Spese: <span className="font-bold">{eur(spese)}</span>
                         </span>
                         {/* Saldo */}
                         <span
@@ -48,10 +43,7 @@ export default function YearDividerRow({
                                     : "text-[hsl(var(--c-table-danger-2))]"
                             }
                         >
-                            <b>
-                                Saldo: {saldo >= 0 ? "+" : ""}
-                                {saldo?.toLocaleString("it-IT", { minimumFractionDigits: 2 })} €
-                            </b>
+                            <b>Saldo: {eur(saldo)}</b>
                         </span>
                     </span>
                 </div>

--- a/Frontend-nextjs/app/(protected)/transazioni/components/list/table/columns.tsx
+++ b/Frontend-nextjs/app/(protected)/transazioni/components/list/table/columns.tsx
@@ -7,6 +7,7 @@ import clsx from "clsx";
 import { ColumnDef, Row } from "@tanstack/react-table";
 import { TransactionWithGroup } from "@/types/transazioni/list";
 import { hexToHSL } from "./utils"; // Importa la funzione dal tuo utils
+import { eur } from "@/utils/formatCurrency";
 
 // ============================
 // Factory: colonne con selezione multipla
@@ -108,11 +109,8 @@ export function getColumnsWithSelection(
                 const type = row.original?.category?.type; // 'entrata' | 'spesa'
                 const sign = type === "entrata" ? "+" : "-";
 
-                // ── 3) Formattazione italiana con 2 decimali (valore assoluto)
-                const formatted = new Intl.NumberFormat("it-IT", {
-                    minimumFractionDigits: 2,
-                    maximumFractionDigits: 2,
-                }).format(Math.abs(safe));
+                // ── 3) Formattazione italiana in euro (valore assoluto)
+                const formatted = eur(Math.abs(safe));
 
                 // ── 4) Rendering con classi colore in base al tipo
                 return (
@@ -125,7 +123,7 @@ export function getColumnsWithSelection(
                         )}
                     >
                         {sign}
-                        {formatted} €
+                        {formatted}
                     </span>
                 );
             },

--- a/Frontend-nextjs/app/(protected)/transazioni/modal/TransactionDetailModal.tsx
+++ b/Frontend-nextjs/app/(protected)/transazioni/modal/TransactionDetailModal.tsx
@@ -13,6 +13,7 @@ import TransactionTypeSwitch from "./components/TransactionTypeSwitch";
 import TransactionDetailForm from "./components/TransactionDetailForm";
 import TransactionActionButtons from "./components/TransactionActionButtons";
 import ConfirmDialog from "../../../components/ui/ConfirmDialog";
+import { eur } from "@/utils/formatCurrency";
 
 // ========== Props tipizzate ==========
 
@@ -173,7 +174,7 @@ export default function TransactionDetailModal({ transaction, onClose, categorie
                     highlight={
                         <div className="flex flex-col items-center">
                             <span className="italic">{transaction.description}</span>
-                            {transaction.amount && <span>{transaction.amount.toFixed(2)}€</span>}
+                            {transaction.amount && <span>{eur(transaction.amount)}</span>}
                             {transaction.category?.name && <span>{transaction.category.name}</span>}
                         </div>
                     }

--- a/Frontend-nextjs/app/(protected)/transazioni/modal/components/field/AmountField.tsx
+++ b/Frontend-nextjs/app/(protected)/transazioni/modal/components/field/AmountField.tsx
@@ -11,7 +11,7 @@ export default function AmountField({ value, onChange, original, showError }: Am
                 min={0.01}
                 step={0.01}
                 value={value}
-                onChange={(e) => onChange(parseFloat(e.target.value))}
+                onChange={(e) => onChange(Number(e.target.value))}
                 className={`w-full text-center rounded-2xl py-3 px-4 border-green-400 shadow-[0_2px_10px_rgba(0,0,0,0.14)] text-lg font-semibold bg-bg-elevate transition ${
                     isModified ? "ring-2 ring-yellow-400" : ""
                 }`}

--- a/Frontend-nextjs/utils/formatCurrency.ts
+++ b/Frontend-nextjs/utils/formatCurrency.ts
@@ -1,0 +1,10 @@
+const formatter = new Intl.NumberFormat("it-IT", {
+    style: "currency",
+    currency: "EUR",
+});
+
+export function eur(amount: number): string {
+    const value = Number(amount);
+    return formatter.format(Number.isFinite(value) ? value : 0);
+}
+


### PR DESCRIPTION
## Summary
- add `eur` formatter helper based on `Intl.NumberFormat`
- replace ad-hoc number parsing and `toLocaleString` calls with the shared helper across tables, modals and cards
- swap `parseFloat` usage for `Number` to avoid string parsing issues

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1d7396b008324a9bf7d08b6c4639b