### PR TITLE
refactor: handle transaction amounts in euros

### DIFF
--- a/Frontend-nextjs/app/(protected)/transazioni/components/list/TransactionTable.tsx
+++ b/Frontend-nextjs/app/(protected)/transazioni/components/list/TransactionTable.tsx
@@ -17,22 +17,6 @@ import { useSelection } from "@/context/SelectionContext";
 import { toNum } from "@/lib/finance";
 
 // =========================
-// Heuristic centesimi (come Context)
-// =========================
-const useAmountsAreCents = (data: TransactionWithGroup[]) => {
-    return useMemo(() => {
-        const nums = data
-            .slice(0, 100)
-            .map((t) => toNum((t as any).amount))
-            .map(Math.abs)
-            .filter(Boolean);
-        if (!nums.length) return false;
-        const over10k = nums.filter((n) => n >= 10_000).length;
-        return over10k / nums.length >= 0.2;
-    }, [data]);
-};
-
-// =========================
 // Calcolo totali mensili (single pass)
 // =========================
 const calcMonthTotals = (rows: Row<TransactionWithGroup>[], amountOf: (tx: TransactionWithGroup) => number) => {
@@ -69,15 +53,8 @@ export default function TransactionTable({
     const dataWithGroups = useMemo(() => addMonthGroup(data), [data]);
     const allIds = useMemo(() => dataWithGroups.map((tx) => tx.id), [dataWithGroups]);
 
-    // Importi in centesimi? (auto-detected)
-    const amountsAreCents = useAmountsAreCents(dataWithGroups);
-    const amountOf = useCallback(
-        (tx: TransactionWithGroup) => {
-            const n = toNum((tx as any).amount);
-            return amountsAreCents ? n / 100 : n;
-        },
-        [amountsAreCents]
-    );
+    // Importi in euro
+    const amountOf = useCallback((tx: TransactionWithGroup) => toNum((tx as any).amount), []);
 
     // Handler stabili
     const handleCheckToggle = useCallback(
@@ -239,7 +216,6 @@ export default function TransactionTable({
 
 // ─────────────────────────────────────────────────────
 // Descrizione file:
-// Tabella transazioni. Usa `toNum` condiviso e mantiene
-// la stessa euristica dei centesimi del Context senza
-// duplicare codice. Totali/Divider coerenti con HeroSaldo.
+// Tabella transazioni. Usa `toNum` condiviso e importi
+// già in euro. Totali/Divider coerenti con HeroSaldo.
 // ─────────────────────────────────────────────────────

--- a/Frontend-nextjs/context/TransactionsContext.tsx
+++ b/Frontend-nextjs/context/TransactionsContext.tsx
@@ -28,7 +28,7 @@ import {
 } from "@/lib/api/transactionsApi";
 
 // ── Helpers condivisi (importi/date/tipo) ──────────────────────────────
-import { parseYMD, detectAmountsAreCents, makeAmountOf, typeOf } from "@/lib/finance";
+import { parseYMD, typeOf } from "@/lib/finance";
 
 // =====================================================================
 // Tipi del context
@@ -165,12 +165,6 @@ export function TransactionsProvider({ children }: { children: React.ReactNode }
     }, [token, fetchAll]);
 
     // =====================================================================
-    // Importi normalizzati (stessa euristica della tabella)
-    // =====================================================================
-    const amountsAreCents = useMemo(() => detectAmountsAreCents(transactions), [transactions]);
-    const amountOf = useMemo(() => makeAmountOf(amountsAreCents), [amountsAreCents]);
-
-    // =====================================================================
     // KPI / Saldi derivati (allineati alla tabella)
     // =====================================================================
     const monthBalance = useMemo(() => {
@@ -184,11 +178,11 @@ export function TransactionsProvider({ children }: { children: React.ReactNode }
                 return d.getFullYear() === y && d.getMonth() === m;
             })
             .reduce((sum, t) => {
-                const amt = amountOf(t);
+                const amt = t.amount;
                 const tt = typeOf(t);
                 return sum + (tt === "entrata" ? amt : tt === "spesa" ? -amt : 0);
             }, 0);
-    }, [transactions, amountOf]);
+    }, [transactions]);
 
     const yearBalance = useMemo(() => {
         const y = new Date().getFullYear();
@@ -196,11 +190,11 @@ export function TransactionsProvider({ children }: { children: React.ReactNode }
         return transactions
             .filter((t) => parseYMD(t.date).getFullYear() === y)
             .reduce((sum, t) => {
-                const amt = amountOf(t);
+                const amt = t.amount;
                 const tt = typeOf(t);
                 return sum + (tt === "entrata" ? amt : tt === "spesa" ? -amt : 0);
             }, 0);
-    }, [transactions, amountOf]);
+    }, [transactions]);
 
     const weekBalance = useMemo(() => {
         const now = new Date();
@@ -219,21 +213,21 @@ export function TransactionsProvider({ children }: { children: React.ReactNode }
                 return d >= first && d <= last;
             })
             .reduce((sum, t) => {
-                const amt = amountOf(t);
+                const amt = t.amount;
                 const tt = typeOf(t);
                 return sum + (tt === "entrata" ? amt : tt === "spesa" ? -amt : 0);
             }, 0);
-    }, [transactions, amountOf]);
+    }, [transactions]);
 
     const totalBalance = useMemo(
-        () =>
-            transactions.reduce((sum, t) => {
-                const amt = amountOf(t);
-                const tt = typeOf(t);
-                return sum + (tt === "entrata" ? amt : tt === "spesa" ? -amt : 0);
-            }, 0),
-        [transactions, amountOf]
-    );
+            () =>
+                transactions.reduce((sum, t) => {
+                    const amt = t.amount;
+                    const tt = typeOf(t);
+                    return sum + (tt === "entrata" ? amt : tt === "spesa" ? -amt : 0);
+                }, 0),
+            [transactions]
+        );
 
     // =====================================================================
     // CREATE / UPDATE / DELETE / MOVE — con aggiornamento ottimistico

--- a/Frontend-nextjs/lib/api/transactionsApi.ts
+++ b/Frontend-nextjs/lib/api/transactionsApi.ts
@@ -9,10 +9,14 @@ import { url } from "@/lib/api/endpoints";
 // Helper: parsing numerico robusto (es. "1.234,56" → 1234.56)
 // ──────────────────────────────────────────────────────
 const toNum = (v: any): number => {
-    if (typeof v === "number") return v;
+    if (typeof v === "number") return Number.isFinite(v) ? v : 0;
     if (typeof v === "string") {
-        const clean = v.replace(/\./g, "").replace(",", ".");
-        const n = Number(clean);
+        const s = v.trim();
+        if (!s) return 0;
+        const normalized = s.includes(",") && s.includes(".")
+            ? s.replace(/\./g, "").replace(",", ".")
+            : s.replace(",", ".");
+        const n = parseFloat(normalized);
         return Number.isFinite(n) ? n : 0;
     }
     const n = Number(v);

--- a/Frontend-nextjs/lib/finance.ts
+++ b/Frontend-nextjs/lib/finance.ts
@@ -12,8 +12,11 @@ export function toNum(v: unknown): number {
     if (typeof v === "string") {
         const s = v.trim();
         if (!s) return 0;
-        const normalized = s.replace(/\./g, "").replace(",", ".");
-        const n = Number(normalized);
+        // Supporta sia "1.234,56" che "1234.56" senza moltiplicare per 100
+        const normalized = s.includes(",") && s.includes(".")
+            ? s.replace(/\./g, "").replace(",", ".")
+            : s.replace(",", ".");
+        const n = parseFloat(normalized);
         return Number.isFinite(n) ? n : 0;
     }
     const n = Number(v);
@@ -29,29 +32,6 @@ export function parseYMD(ymd: string): Date {
     dt.setFullYear(y, (m || 1) - 1, d || 1);
     dt.setHours(0, 0, 0, 0);
     return dt;
-}
-
-// ──────────────────────────────────────────────────────
-// Heuristica: importi in centesimi? (≥20% >= 10_000)
-// ──────────────────────────────────────────────────────
-export function detectAmountsAreCents(transactions: Pick<Transaction, "amount">[], sampleSize = 100): boolean {
-    const sample = transactions
-        .slice(0, sampleSize)
-        .map((t) => Math.abs(toNum((t as any).amount)))
-        .filter(Boolean);
-    if (!sample.length) return false;
-    const over10k = sample.filter((n) => n >= 10_000).length;
-    return over10k / sample.length >= 0.2;
-}
-
-// ──────────────────────────────────────────────────────
-// Factory: amountOf con flag centesimi già deciso
-// ──────────────────────────────────────────────────────
-export function makeAmountOf(amountsAreCents: boolean) {
-    return (t: Pick<Transaction, "amount">) => {
-        const n = toNum((t as any).amount);
-        return amountsAreCents ? n / 100 : n;
-    };
 }
 
 // ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- parse API decimal amounts directly to numbers
- drop cent-based heuristics and use euro amounts throughout the frontend
- compute balances using euro values

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b1ede383fc832482d89f2ffeaa6449