### PR TITLE
Fix currency calculations for overview and transactions pages

### DIFF
--- a/Frontend-nextjs/app/(protected)/panoramica/components/calendar/DayCell.tsx
+++ b/Frontend-nextjs/app/(protected)/panoramica/components/calendar/DayCell.tsx
@@ -10,10 +10,10 @@
 import { Transaction } from "@/types/models/transaction";
 import type { DayCellProps } from "@/types";
 import { eur } from "@/utils/formatCurrency";
+import { toNum } from "@/lib/finance";
 
 // ----------- Funzione somma importi ----------- //
-const somma = (arr: Transaction[]) =>
-    arr.reduce((tot, t) => tot + (typeof t.amount === "string" ? Number(t.amount) : t.amount), 0);
+const somma = (arr: Transaction[]) => arr.reduce((tot, t) => tot + toNum((t as any).amount), 0);
 
 // ----------- Componente principale ----------- //
 export default function DayCell({
@@ -115,7 +115,7 @@ export default function DayCell({
                             style={{ height: `${barEntrate}px`, minHeight: `${minHeight}px` }}
                         >
                             <span className="absolute bottom-0 left-1/2 -translate-x-1/2 text-[10px] text-bg font-semibold">
-                                {eur(Math.round(totaleEntrate))}
+                                {eur(totaleEntrate)}
                             </span>
                         </div>
                         <span className="mt-0.5 text-[8px] text-primary font-semibold">Entrate</span>
@@ -129,7 +129,7 @@ export default function DayCell({
                             style={{ height: `${barSpese}px`, minHeight: `${minHeight}px` }}
                         >
                             <span className="absolute bottom-0 left-1/2 -translate-x-1/2 text-[10px] text-bg font-semibold">
-                                {eur(Math.round(totaleSpese))}
+                                {eur(totaleSpese)}
                             </span>
                         </div>
                         <span className="mt-0.5 text-[8px] text-orange-400 font-semibold">Spese</span>

--- a/Frontend-nextjs/app/(protected)/panoramica/components/modal/DayTransactionsModal.tsx
+++ b/Frontend-nextjs/app/(protected)/panoramica/components/modal/DayTransactionsModal.tsx
@@ -7,6 +7,7 @@ import { useTransactions } from "@/context/TransactionsContext";
 import { CATEGORY_ICONS_MAP } from "@/utils/categoryOptions";
 import { toDateInputValue } from "@/utils/date";
 import { eur } from "@/utils/formatCurrency";
+import { toNum } from "@/lib/finance";
 import { FiTag } from "react-icons/fi";
 
 export type DayTransactionsModalProps = {
@@ -22,8 +23,7 @@ export default function DayTransactionsModal({ open, onClose, date, transactions
     // Suddividi per tipo e calcola totali
     const entrate = transactions.filter((t) => t.category?.type === "entrata");
     const spese = transactions.filter((t) => t.category?.type === "spesa");
-    const somma = (arr: Transaction[]) =>
-        arr.reduce((tot, t) => tot + (typeof t.amount === "string" ? Number(t.amount) : t.amount), 0);
+    const somma = (arr: Transaction[]) => arr.reduce((tot, t) => tot + toNum((t as any).amount), 0);
     const totalEntrate = somma(entrate);
     const totalSpese = somma(spese);
 
@@ -117,8 +117,7 @@ export default function DayTransactionsModal({ open, onClose, date, transactions
                                             }`}
                                         >
                                             {(() => {
-                                                const amount =
-                                                    typeof t.amount === "string" ? Number(t.amount) : t.amount;
+                                                const amount = toNum((t as any).amount);
                                                 return eur(amount);
                                             })()}
                                         </span>

--- a/Frontend-nextjs/context/TransactionsContext.tsx
+++ b/Frontend-nextjs/context/TransactionsContext.tsx
@@ -28,7 +28,7 @@ import {
 } from "@/lib/api/transactionsApi";
 
 // ── Helpers condivisi (importi/date/tipo) ──────────────────────────────
-import { parseYMD, typeOf } from "@/lib/finance";
+import { parseYMD, typeOf, toNum } from "@/lib/finance";
 
 // =====================================================================
 // Tipi del context
@@ -178,7 +178,7 @@ export function TransactionsProvider({ children }: { children: React.ReactNode }
                 return d.getFullYear() === y && d.getMonth() === m;
             })
             .reduce((sum, t) => {
-                const amt = t.amount;
+                const amt = toNum((t as any).amount);
                 const tt = typeOf(t);
                 return sum + (tt === "entrata" ? amt : tt === "spesa" ? -amt : 0);
             }, 0);
@@ -190,7 +190,7 @@ export function TransactionsProvider({ children }: { children: React.ReactNode }
         return transactions
             .filter((t) => parseYMD(t.date).getFullYear() === y)
             .reduce((sum, t) => {
-                const amt = t.amount;
+                const amt = toNum((t as any).amount);
                 const tt = typeOf(t);
                 return sum + (tt === "entrata" ? amt : tt === "spesa" ? -amt : 0);
             }, 0);
@@ -213,7 +213,7 @@ export function TransactionsProvider({ children }: { children: React.ReactNode }
                 return d >= first && d <= last;
             })
             .reduce((sum, t) => {
-                const amt = t.amount;
+                const amt = toNum((t as any).amount);
                 const tt = typeOf(t);
                 return sum + (tt === "entrata" ? amt : tt === "spesa" ? -amt : 0);
             }, 0);
@@ -222,7 +222,7 @@ export function TransactionsProvider({ children }: { children: React.ReactNode }
     const totalBalance = useMemo(
             () =>
                 transactions.reduce((sum, t) => {
-                    const amt = t.amount;
+                    const amt = toNum((t as any).amount);
                     const tt = typeOf(t);
                     return sum + (tt === "entrata" ? amt : tt === "spesa" ? -amt : 0);
                 }, 0),


### PR DESCRIPTION
## Summary
- Normalize transaction amounts using `toNum` in transaction context balance computations
- Ensure daily calendar and modal totals parse amounts with `toNum` and display full precision

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b310ae20a0832482d00017c5b2dca8